### PR TITLE
Simple support for og:* and fb:* tags

### DIFF
--- a/Resources/config/facebook.xml
+++ b/Resources/config/facebook.xml
@@ -1,62 +1,76 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://www.symfony-project.org/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
 
-  <parameters>
-    <!-- parameters used in both the js and php api classes -->
-    <parameter key="fos_facebook.file">null</parameter>
-    <parameter key="fos_facebook.app_id">null</parameter>
-    <parameter key="fos_facebook.cookie">false</parameter>
+	<parameters>
+		<!-- parameters used in both the js and php api classes -->
+		<parameter key="fos_facebook.file">null</parameter>
+		<parameter key="fos_facebook.app_id">null</parameter>
+		<parameter key="fos_facebook.cookie">false</parameter>
 
-    <!-- parameters used by the php api -->
-    <parameter key="fos_facebook.class">Facebook</parameter>
-    <parameter key="fos_facebook.secret">null</parameter>
-    <parameter key="fos_facebook.domain">null</parameter>
+		<!-- parameters used by the php api -->
+		<parameter key="fos_facebook.class">Facebook</parameter>
+		<parameter key="fos_facebook.secret">null</parameter>
+		<parameter key="fos_facebook.domain">null</parameter>
 
-    <!-- parameters used by the js api -->
-    <parameter key="fos_facebook.logging">%kernel.debug%</parameter>
-    <parameter key="fos_facebook.culture">en_US</parameter>
+		<!-- parameters used by the js api -->
+		<parameter key="fos_facebook.logging">%kernel.debug%</parameter>
+		<parameter key="fos_facebook.culture">en_US</parameter>
 
-    <parameter key="fos_facebook.permissions" type="collection"></parameter>
-    
-    <parameter key="fos_facebook.login_url.cancel_url">null</parameter>
-    <parameter key="fos_facebook.login_url.canvas">0</parameter>
-    <parameter key="fos_facebook.login_url.display">page</parameter>
-    <parameter key="fos_facebook.login_url.fbconnect">1</parameter>
-    <parameter key="fos_facebook.login_url.next">null</parameter>
+		<parameter key="fos_facebook.permissions" type="collection"></parameter>
 
-    <parameter key="fos_facebook.helper.class">Bundle\FOS\FacebookBundle\Templating\Helper\FacebookHelper</parameter>
-    <parameter key="fos_facebook.twig.extension.class">Bundle\FOS\FacebookBundle\Twig\Extension\FacebookExtension</parameter>
-  </parameters>
+		<parameter key="fos_facebook.login_url.cancel_url">null</parameter>
+		<parameter key="fos_facebook.login_url.canvas">0</parameter>
+		<parameter key="fos_facebook.login_url.display">page</parameter>
+		<parameter key="fos_facebook.login_url.fbconnect">1</parameter>
+		<parameter key="fos_facebook.login_url.next">null</parameter>
 
-  <services>
+		<parameter key="fos_facebook.helper.class">Bundle\FOS\FacebookBundle\Templating\Helper\FacebookHelper</parameter>
 
-    <service id="fos_facebook.api" class="%fos_facebook.class%">
-      <file>%fos_facebook.file%</file>
-      <argument type="collection">
-        <argument key="appId">%fos_facebook.app_id%</argument>
-        <argument key="secret">%fos_facebook.secret%</argument>
-        <argument key="cookie">%fos_facebook.cookie%</argument>
-        <argument key="domain">%fos_facebook.domain%</argument>
-      </argument>
-    </service>
+		<parameter key="fos_facebook.helper.fbmetatags.class">Bundle\FOS\FacebookBundle\Templating\Helper\FbMetatagsHelper</parameter>
+		<parameter key="fos_facebook.helper.ogmetatags.class">Bundle\FOS\FacebookBundle\Templating\Helper\OgMetatagsHelper</parameter>
 
-    <service id="fos_facebook.helper" class="%fos_facebook.helper.class%">
-      <argument type="service" id="templating" />
-      <argument>%fos_facebook.app_id%</argument>
-      <argument>%fos_facebook.cookie%</argument>
-      <argument>%fos_facebook.logging%</argument>
-      <argument>%fos_facebook.culture%</argument>
-      <argument>%fos_facebook.permissions%</argument>
-      <tag name="templating.helper" alias="facebook" />
-    </service>
+		<parameter key="fos_facebook.twig.extension.class">Bundle\FOS\FacebookBundle\Twig\Extension\FacebookExtension</parameter>
+	</parameters>
 
-    <service id="fos_facebook.twig" class="%fos_facebook.twig.extension.class%">
-      <argument type="service" id="fos_facebook.helper" />
-      <tag name="twig.extension" />
-    </service>
+	<services>
 
-  </services>
+		<service id="fos_facebook.api" class="%fos_facebook.class%">
+			<file>%fos_facebook.file%</file>
+			<argument type="collection">
+				<argument key="appId">%fos_facebook.app_id%</argument>
+				<argument key="secret">%fos_facebook.secret%</argument>
+				<argument key="cookie">%fos_facebook.cookie%</argument>
+				<argument key="domain">%fos_facebook.domain%</argument>
+			</argument>
+		</service>
+
+		<service id="fos_facebook.helper" class="%fos_facebook.helper.class%">
+			<argument type="service" id="templating" />
+			<argument>%fos_facebook.app_id%</argument>
+			<argument>%fos_facebook.cookie%</argument>
+			<argument>%fos_facebook.logging%</argument>
+			<argument>%fos_facebook.culture%</argument>
+			<argument>%fos_facebook.permissions%</argument>
+			<tag name="templating.helper" alias="facebook" />
+		</service>
+
+
+		<service id="fos_facebook.helper.ogmetatags" class="%fos_facebook.helper.ogmetatags.class%">
+			<tag name="templating.helper" alias="ogmetatags" />
+		</service>
+		
+		
+		<service id="fos_facebook.helper.fbmetatags" class="%fos_facebook.helper.fbmetatags.class%">
+			<argument>%fos_facebook.app_id%</argument>
+			<tag name="templating.helper" alias="fbmetatags" />
+		</service>
+		
+		<service id="fos_facebook.twig" class="%fos_facebook.twig.extension.class%">
+			<argument type="service" id="fos_facebook.helper" />
+			<tag name="twig.extension" />
+		</service>
+	</services>
 </container>

--- a/Templating/Helper/FbMetatagsHelper.php
+++ b/Templating/Helper/FbMetatagsHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Templating\Helper;
+
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * FbMetatagsHelper is a helper that manages fb:* tags.
+ *
+ * Usage:
+ *
+ * <code>
+ *   $view['fbmetatags']->add('admins', 'USER_ID');
+ *   $view['fbmetatags']->add('app_id', 'APP_ID');
+ *   echo $view['fbmetatags'];
+ * </code>
+ *
+ * @author Marcin Sikoń <marcin.sikon@gmail.com>
+ */
+class FbMetatagsHelper extends MetatagsHelper
+{
+    public function __construct($appId)
+    {
+        $this->add('app_id', $appId);
+    }
+
+
+    /**
+     * Returns a tag namespace
+     *
+     * @return string namespace
+     */
+    public function getNamespace()
+    {
+        return 'fb';
+    }
+
+    /**
+     * Returns the canonical name of this helper.
+     *
+     * @return string The canonical name
+     */
+    public function getName()
+    {
+        return 'fbmetatags';
+    }
+}

--- a/Templating/Helper/MetatagsHelper.php
+++ b/Templating/Helper/MetatagsHelper.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Templating\Helper;
+
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * MetatagsHelper is base class for FbMetatagsHelper and OgMetatagsHelper
+ *
+ *
+ * @author Marcin Sikoń <marcin.sikon@gmail.com>
+ */
+abstract class MetatagsHelper extends Helper
+{
+    protected $tags = array();
+
+    
+    abstract public function getNamespace();
+    
+
+    /**
+     * Adds a metatag
+     *
+     * @param string $property Property
+     * @param string $content Content
+     */
+    public function add($property, $content)
+    {
+        $this->tags[$property] = $content;
+    }
+
+    /**
+     * Returns all tags.
+     *
+     * @return array An array of tags
+     */
+    public function get()
+    {
+        return $this->tags;
+    }
+    
+     
+    /**
+     * Returns HTML representation of the meta tags.
+     *
+     * @return string The HTML representation of the meta tags.
+     */
+    public function render()
+    {
+        $html = '';
+        foreach ($this->tags as $property => $content) {
+            $html .= sprintf('<meta property="%s" content="%s" />', $this->getNamespace().':'.$property, htmlspecialchars($content, ENT_QUOTES, $this->charset))."\n";
+        }
+
+        return $html;
+    }
+    
+
+    /**
+     * Outputs HTML representation of the metatags.
+     *
+     */
+    public function output()
+    {
+        echo $this->render();
+    }
+
+    /**
+     * Returns a string representation of this helper as HTML.
+     *
+     * @return string The HTML representation of meta tags.
+     */
+    public function __toString()
+    {
+        return $this->render();
+    }
+    
+}

--- a/Templating/Helper/OgMetatagsHelper.php
+++ b/Templating/Helper/OgMetatagsHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Templating\Helper;
+
+
+/**
+ * OgMetatagsHelper is a helper that manages og:* tags.
+ *
+ * Usage:
+ *
+ * <code>
+ *   $view['ogmetatags']->add('title', 'The Rock');
+ *   $view['ogmetatags']->add('type', 'movie');
+ *   $view['ogmetatags']->add('image', 'http://ia.media-imdb.com/rock.jpg');
+ *   $view['ogmetatags']->add('site_name', 'IMDb');
+ *   
+ *   echo $view['ogmetatags'];
+ * </code>
+ *
+ * @author Marcin Sikoń <marcin.sikon@gmail.com>
+ */
+class OgMetatagsHelper extends MetatagsHelper
+{
+
+    /**
+     * Returns a tag namespace 
+     *
+     * @return string namespace
+     */
+    public function getNamespace()
+    {
+        return 'og';
+    }
+
+    /**
+     * Returns the canonical name of this helper.
+     *
+     * @return string The canonical name
+     */
+    public function getName()
+    {
+        return 'ogmetatags';
+    }
+}

--- a/Tests/Templating/Helper/FbMetatagsHelperTest.php
+++ b/Tests/Templating/Helper/FbMetatagsHelperTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Tests\Templating\Helper;
+
+use Bundle\FOS\FacebookBundle\Templating\Helper\FbMetatagsHelper;
+
+class FbMetatagsHelperTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function defaultAppIdTag()
+    {
+        $helper = new FbMetatagsHelper(123);
+
+        $this->assertSame(array('app_id' => 123), $helper->get());
+    }
+
+    /**
+     * @test
+     */
+    public function render()
+    {
+        $expected = '<meta property="fb:app_id" content="123" />'.PHP_EOL.'<meta property="fb:admins" content="456" />'.PHP_EOL;
+
+        $helper = new FbMetatagsHelper(123);
+        $helper->add('admins', 456);
+
+
+        $this->assertSame($expected, $helper->render());
+    }
+}

--- a/Tests/Templating/Helper/OgMetatagsHelperTest.php
+++ b/Tests/Templating/Helper/OgMetatagsHelperTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Tests\Templating\Helper;
+
+use Bundle\FOS\FacebookBundle\Templating\Helper\OgMetatagsHelper;
+
+class OgMetatagsHelperTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function defaultTag()
+    {
+        $helper = new OgMetatagsHelper();
+        $this->assertSame(array(), $helper->get());
+    }
+
+    /**
+     * @test
+     */
+    public function render()
+    {
+        $expected = '<meta property="og:title" content="The Rock" />'.PHP_EOL.'<meta property="og:type" content="move" />'.PHP_EOL;
+
+        $helper = new OgMetatagsHelper();
+        $helper->add('title', 'The Rock');
+        $helper->add('type', 'move');
+
+        $this->assertSame($expected, $helper->render());
+    }
+}

--- a/Twig/Extension/FacebookExtension.php
+++ b/Twig/Extension/FacebookExtension.php
@@ -2,7 +2,11 @@
 
 namespace Bundle\FOS\FacebookBundle\Twig\Extension;
 
-use Bundle\FOS\FacebookBundle\Twig\TokenParser\FacebookTokenParser;
+use Bundle\FOS\FacebookBundle\Twig\TokenParser\OgMetatagsTokenParser;
+use Bundle\FOS\FacebookBundle\Twig\TokenParser\OgMetatagTokenParser;
+use Bundle\FOS\FacebookBundle\Twig\TokenParser\FbMetatagsTokenParser;
+use Bundle\FOS\FacebookBundle\Twig\TokenParser\FbMetatagTokenParser;
+
 
 /**
  *
@@ -37,6 +41,28 @@ class FacebookExtension extends \Twig_Extension
     public function getName()
     {
         return 'facebook';
+    }
+    
+ /**
+     * Returns the token parser instance to add to the existing list.
+     *
+     * @return array An array of Twig_TokenParser instances
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            // {% ogmetatag 'title' 'The Rock' %}
+            new OgMetatagTokenParser(),
+
+            // {% ogmetatags %}
+            new OgMetatagsTokenParser(),
+            
+            // {% fbmetatag 'admins' 'USER_ID' %}
+            new FbMetatagTokenParser(),
+
+            // {% fbmetatags %}
+            new FbMetatagsTokenParser(),
+        );
     }
 
     public function renderInitialize($parameters = array(), $name = null)

--- a/Twig/Node/FbMetatagNode.php
+++ b/Twig/Node/FbMetatagNode.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace  Bundle\FOS\FacebookBundle\Twig\Node;
+
+
+
+class FbMetatagNode extends \Twig_Node
+{
+    public function __construct(\Twig_Node_Expression $property, \Twig_Node_Expression $content, $lineno, $tag = null)
+    {
+        parent::__construct(array('property' => $property, 'content' => $content), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("echo \$this->env->getExtension('templating')->getContainer()->get('fos_facebook.helper.fbmetatags')->add(")
+            ->subcompile($this->getNode('property'))
+            ->raw(', ')
+            ->subcompile($this->getNode('content'))
+            ->raw(");\n")
+        ;
+    }
+}

--- a/Twig/Node/FbMetatagsNode.php
+++ b/Twig/Node/FbMetatagsNode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\Node;
+
+
+
+
+class FbMetatagsNode extends \Twig_Node
+{
+    public function __construct($lineno, $tag = null)
+    {
+        parent::__construct(array(), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("echo \$this->env->getExtension('templating')->getContainer()->get('fos_facebook.helper.fbmetatags')->render();\n")
+        ;
+    }
+}

--- a/Twig/Node/OgMetatagNode.php
+++ b/Twig/Node/OgMetatagNode.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace  Bundle\FOS\FacebookBundle\Twig\Node;
+
+
+
+/**
+ * Represents a javascript node.
+ *
+ * @author Fabien Potencier <fabien.potencier@symfony-project.com>
+ */
+class OgMetatagNode extends \Twig_Node
+{
+    public function __construct(\Twig_Node_Expression $property, \Twig_Node_Expression $content, $lineno, $tag = null)
+    {
+        parent::__construct(array('property' => $property, 'content' => $content), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("echo \$this->env->getExtension('templating')->getContainer()->get('fos_facebook.helper.ogmetatags')->add(")
+            ->subcompile($this->getNode('property'))
+            ->raw(', ')
+            ->subcompile($this->getNode('content'))
+            ->raw(");\n")
+        ;
+    }
+}

--- a/Twig/Node/OgMetatagsNode.php
+++ b/Twig/Node/OgMetatagsNode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\Node;
+
+
+
+
+class OgMetatagsNode extends \Twig_Node
+{
+    public function __construct($lineno, $tag = null)
+    {
+        parent::__construct(array(), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write("echo \$this->env->getExtension('templating')->getContainer()->get('fos_facebook.helper.ogmetatags')->render();\n")
+        ;
+    }
+}

--- a/Twig/TokenParser/FbMetatagTokenParser.php
+++ b/Twig/TokenParser/FbMetatagTokenParser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\TokenParser;
+
+
+use Bundle\FOS\FacebookBundle\Twig\Node\FbMetatagNode;
+
+class FbMetatagTokenParser extends \Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A \Twig_Token instance
+     *
+     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $property = $this->parser->getExpressionParser()->parseExpression();
+        $content = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new FbMetatagNode($property, $content, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @param string The tag name
+     */
+    public function getTag()
+    {
+        return 'fbmetatag';
+    }
+}

--- a/Twig/TokenParser/FbMetatagsTokenParser.php
+++ b/Twig/TokenParser/FbMetatagsTokenParser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\TokenParser;
+
+
+
+use Bundle\FOS\FacebookBundle\Twig\Node\FbMetatagsNode;
+
+class FbMetatagsTokenParser extends \Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A \Twig_Token instance
+     *
+     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new FbMetatagsNode($token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @param string The tag name
+     */
+    public function getTag()
+    {
+        return 'fbmetatags';
+    }
+}

--- a/Twig/TokenParser/OgMetatagTokenParser.php
+++ b/Twig/TokenParser/OgMetatagTokenParser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\TokenParser;
+
+
+
+use Bundle\FOS\FacebookBundle\Twig\Node\OgMetatagNode;
+
+class OgMetatagTokenParser extends \Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A \Twig_Token instance
+     *
+     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $property = $this->parser->getExpressionParser()->parseExpression();
+        $content = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new OgMetatagNode($property, $content, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @param string The tag name
+     */
+    public function getTag()
+    {
+        return 'ogmetatag';
+    }
+}

--- a/Twig/TokenParser/OgMetatagsTokenParser.php
+++ b/Twig/TokenParser/OgMetatagsTokenParser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bundle\FOS\FacebookBundle\Twig\TokenParser;
+
+
+
+use Bundle\FOS\FacebookBundle\Twig\Node\OgMetatagsNode;
+
+class OgMetatagsTokenParser extends \Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A \Twig_Token instance
+     *
+     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new OgMetatagsNode($token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @param string The tag name
+     */
+    public function getTag()
+    {
+        return 'ogmetatags';
+    }
+}


### PR DESCRIPTION
Usage:
    {% fbmetatag 'admins' 'USER_ID' %}
    {% ogmetatag 'title' 'The Rock' %}
    {% ogmetatag 'type' 'move' %}

```
{% fbmetatags %}
{% ogmetatags %}
```

Result:
    <meta property="fb:app_id" content="123" />
    <meta property="fb:admins" content="USER_ID" />
    <meta property="og:title" content="The Rock" />
    <meta property="og:type" content="move" />
