### PR TITLE
Fix entrypoint

### DIFF
--- a/DependencyInjection/Security/Factory/FacebookFactory.php
+++ b/DependencyInjection/Security/Factory/FacebookFactory.php
@@ -15,7 +15,6 @@ class FacebookFactory extends AbstractFactory
         $this->addOption('canvas', 0);
         $this->addOption('display', 'page');
         $this->addOption('fbconnect', 1);
-        $this->addOption('permissions', array());
     }
 
     public function getPosition()

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -18,6 +18,7 @@
         <service id="fos_facebook.security.authentication.entry_point" class="FOS\FacebookBundle\Security\EntryPoint\FacebookAuthenticationEntryPoint" public="false" abstract="true">
             <argument type="service" id="fos_facebook.api" />
             <argument type="collection" />
+            <argument>%fos_facebook.permissions%</argument>
         </service>
 
     </services>

--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -19,6 +19,7 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
 {
     protected $facebook;
     protected $options;
+    protected $permissions;
 
     /**
      * Constructor
@@ -26,9 +27,10 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
      * @param Facebook $facebook
      * @param array    $options
      */
-    public function __construct(\Facebook $facebook, array $options = array())
+    public function __construct(\Facebook $facebook, array $options = array(), array $permssions = array())
     {
         $this->facebook = $facebook;
+        $this->permssions = $permssions;
         $this->options = new ParameterBag($options);
     }
 
@@ -43,7 +45,7 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
                 'canvas' => $this->options->get('canvas', 0),
                 'display' => $this->options->get('display', 'page'),
                 'fbconnect' => $this->options->get('fbconnect', 1),
-                'permissions' => implode(',', $this->options->get('permissions', array())),
+                'permissions' => implode(',', $this->permssions),
                 'next' => $request->getUriForPath($this->options->get('check_path', '')),
             ))
         );


### PR DESCRIPTION
IMHO FacebookAuthenticationEntryPoint should return redirect response with loginUrl having permissions from DI configuration (%fos_facebook.permissions%).  

Now my config file looks like:
    #application/config/config.yml
    fos_facebook:
        ....
        permssions: [publish_stream]

facebook_login_button return loginUrl with permission parameter but  FacebookAuthenticationEntryPoint without permission
