### PR TITLE
Avoid generating useless tokens per default

### DIFF
--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -60,7 +60,7 @@ class FacebookProvider implements AuthenticationProviderInterface
     protected function createAuthenticatedToken($uid)
     {
         if (null === $this->userProvider) {
-            return new FacebookUserToken($uid);
+            throw new AuthenticationException('No Facebook user provider available.');
         }
 
         $user = $this->userProvider->loadUserByUsername($uid);


### PR DESCRIPTION
My configuration let to the following in app/cache/dev/appDevDebug/ProjectContainer.php

```
protected function getSecurity_Authentication_ManagerService()
{
    $a = $this->get('fos_facebook.api');

    return $this->services['security.authentication.manager'] = new \Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager(array(
        0 => new \FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider($a, $this->get('fos_facebook.user_provider'), new \Symfony\Component\Security\Core\User\UserChecker()),
        1 => new \Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider('SomeRandomValue'),
        2 => new \FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider($a)
    ));
}
```

You see that an instance of FacebookProvider is passed twice. The first is a result of my apps configuration and is fully qualified while the second is coming from the bundles config as a default.

As the provider currently always returns an empty token when no user provider is given this empty token will always override the previous one which was properly authenticated.

See also related to this: https://github.com/symfony/symfony/pull/274
