### PR TITLE
Fb event subscribe fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ still needs to be triggered. To do this you will in most cases simply subscribe
 to the "auth.login" event and then redirect to the "check_path":
 
     <script type="text/javascript">
-         window.fbAsyncInit = (function(originalFunc) {
+    //<![CDATA[
+        window.fbAsyncInit = (function(originalFunc) {
             return function() {
                 if (originalFunc) originalFunc();
                 FB.Event.subscribe('auth.login', function(response) {
@@ -238,6 +239,7 @@ to the "auth.login" event and then redirect to the "check_path":
                 });
             };
         })(window.fbAsyncInit);
+    //]]>
     </script>
 
 The "_security_check" route would need to point to a "/login_check" pattern

--- a/README.md
+++ b/README.md
@@ -241,12 +241,16 @@ to the "auth.login" event and then redirect to the "check_path":
                 FB.Event.subscribe('auth.login', function(response) {
                    window.location.href = "{{ path('_security_check') }}";
                 });
+                FB.Event.subscribe('auth.logout', function(response) {
+                   window.location.href = "{{ path('_security_logout') }}";
+                });
             };
         })(window.fbAsyncInit);
     </script>
 
 The "_security_check" route would need to point to a "/login_check" pattern
-to match the above configuration.
+to match the above configuration. The "_security_logout" route should point to
+your logout URL ("/logout" by default).
 
 Example Customer User Provider using the FOS\UserBundle
 -------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -97,15 +97,7 @@ Installation
               app_id: 123456879
               secret: s3cr3t
               cookie: true
-<<<<<<< HEAD
-<<<<<<< HEAD
-              permissions: [email, user_birthday, user_location]
-=======
               permissions: ['email']
->>>>>>> fixed wrong javascript instruction in readme
-=======
-              permissions: [email, user_birthday, user_location]
->>>>>>> merged with FOS updates
 
           # application/config/config.xml
           <fos_facebook:api

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ Installation
               app_id: 123456879
               secret: s3cr3t
               cookie: true
+<<<<<<< HEAD
               permissions: [email, user_birthday, user_location]
+=======
+              permissions: ['email']
+>>>>>>> fixed wrong javascript instruction in readme
 
           # application/config/config.xml
           <fos_facebook:api
@@ -226,10 +230,15 @@ be handled. The step of logging in the user into your Symfony2 application
 still needs to be triggered. To do this you will in most cases simply subscribe
 to the "auth.login" event and then redirect to the "check_path":
 
-    <script>
-      FB.Event.subscribe('auth.login', function(response) {
-        window.location = {{ path('_security_check') }};
-      });
+    <script type="text/javascript">
+         window.fbAsyncInit = (function(originalFunc) {
+            return function() {
+                if (originalFunc) originalFunc();
+                FB.Event.subscribe('auth.login', function(response) {
+                   window.location.href = "{{ path('_security_check') }}";
+                });
+            };
+        })(window.fbAsyncInit);
     </script>
 
 The "_security_check" route would need to point to a "/login_check" pattern

--- a/README.md
+++ b/README.md
@@ -98,10 +98,14 @@ Installation
               secret: s3cr3t
               cookie: true
 <<<<<<< HEAD
+<<<<<<< HEAD
               permissions: [email, user_birthday, user_location]
 =======
               permissions: ['email']
 >>>>>>> fixed wrong javascript instruction in readme
+=======
+              permissions: [email, user_birthday, user_location]
+>>>>>>> merged with FOS updates
 
           # application/config/config.xml
           <fos_facebook:api

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -1,16 +1,13 @@
 <div id="fb-root"></div>
-{% if not async %}
-<script type="text/javascript" src="http://connect.facebook.net/{{ culture }}/all.js"></script>
-{% endif %}
+
 <script type="text/javascript">
 {% autoescape false %}
-{% if async %}
-window.fbAsyncInit = function() {
-{% endif %}
-  FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging }|json_encode }});
-{% if async %}
-  {{ fbAsyncInit }}
-};
+window.fbAsyncInit = (function(originalFunc) {
+    return function() {
+        if (originalFunc) originalFunc();
+        FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging }|json_encode }});
+    };
+})(window.fbAsyncInit);
 
 (function() {
   var e = document.createElement('script');
@@ -18,6 +15,5 @@ window.fbAsyncInit = function() {
   e.async = true;
   document.getElementById('fb-root').appendChild(e);
 }());
-{% endif %}
 {% endautoescape %}
 </script>

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -2,6 +2,7 @@
 
 <script type="text/javascript">
 {% autoescape false %}
+//<![CDATA[
 window.fbAsyncInit = (function(originalFunc) {
     return function() {
         if (originalFunc) originalFunc();
@@ -15,5 +16,6 @@ window.fbAsyncInit = (function(originalFunc) {
   e.async = true;
   document.getElementById('fb-root').appendChild(e);
 }());
+//]]>
 {% endautoescape %}
 </script>

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -13,7 +13,6 @@ namespace FOS\FacebookBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Templating\EngineInterface;
-use \Facebook;
 
 class FacebookHelper extends Helper
 {

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -52,8 +52,6 @@ class FacebookHelper extends Helper
      */
     public function initialize($parameters = array(), $name = null)
     {
-        $session = $this->facebook->getSession();
-
         $name = $name ?: 'FOSFacebookBundle::initialize.html.php';
         return $this->templating->render($name, $parameters + array(
             'async'       => true,

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -13,6 +13,7 @@ namespace FOS\FacebookBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Templating\EngineInterface;
+use \Facebook;
 
 class FacebookHelper extends Helper
 {
@@ -51,6 +52,8 @@ class FacebookHelper extends Helper
      */
     public function initialize($parameters = array(), $name = null)
     {
+        $session = $this->facebook->getSession();
+
         $name = $name ?: 'FOSFacebookBundle::initialize.html.php';
         return $this->templating->render($name, $parameters + array(
             'async'       => true,


### PR DESCRIPTION
Hi there!
Sorry this is 4 commits, but i realised too late that this should be pushed to your side. At least i think so.
When i follow your instructions, subscribing to events is simply not possible.
Reason:
This code gets executed before FB class is even loaded. 

<pre>

             FB.Event.subscribe('auth.login', function(response) {
                 window.location.href = '{{ path("_security_check") }}';
             });
</pre>

The result is following javascript error message (Firefox 4): "FB is not defined".
This PR is about fixing this issue.

Best Regards,
Stephan
