### PR TITLE
Adding the uid to the Token

### DIFF
--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -69,7 +69,7 @@ class FacebookSessionPersistence extends \BaseFacebook
      */
     protected function clearAllPersistentData()
     {
-        foreach ($this->session->all() as $k => $v) {
+        foreach ($this->session->getAttributes() as $k => $v) {
             if (0 !== strpos($k, $this->prefix)) {
                 continue;
             }

--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -69,7 +69,7 @@ class FacebookSessionPersistence extends \BaseFacebook
      */
     protected function clearAllPersistentData()
     {
-        foreach ($this->session->getAttributes() as $k => $v) {
+        foreach ($this->session->all() as $k => $v) {
             if (0 !== strpos($k, $this->prefix)) {
                 continue;
             }

--- a/Resources/views/initialize.html.php
+++ b/Resources/views/initialize.html.php
@@ -13,6 +13,12 @@ window.fbAsyncInit = function() {
     'status'  => $status,
     'cookie'  => $cookie,
     'logging' => $logging)) ?>);
+  FB.Event.subscribe('auth.login', function(response) {
+    window.location = <?php echo json_encode($login_url) ?>;
+  });
+  FB.Event.subscribe('auth.logout', function(response) {
+    window.location = <?php echo json_encode($logout_url) ?>;
+  });
 <?php if (!empty($async)) { ?>
     <?php echo $fbAsyncInit ?>
   };

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -8,6 +8,12 @@
 window.fbAsyncInit = function() {
 {% endif %}
   FB.init({{ {'appId':appId, 'xfbml':xfbml, 'session':session, 'status':status, 'cookie':cookie, 'logging':logging }|json_encode }});
+  FB.Event.subscribe('auth.login', function(response) {
+    window.location = '{{ login_url }}';
+  });
+  FB.Event.subscribe('auth.logout', function(response) {
+    window.location = '{{ logout_url }}';
+  });
 {% if async %}
   {{ fbAsyncInit }}
 };

--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -48,6 +48,7 @@ class FacebookProvider implements AuthenticationProviderInterface
 
         try {
             if ($uid = $this->facebook->getUser()) {
+                $token->setUser($uid);
                 return $this->createAuthenticatedToken($uid);
             }
         } catch (AuthenticationException $failed) {

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -52,6 +52,17 @@ class FacebookHelper extends Helper
     public function initialize($parameters = array(), $name = null)
     {
         $name = $name ?: 'FOSFacebookBundle::initialize.html.php';
+        $loginParams = array();
+        if(isset($parameters["login_url"])){
+            $loginParams["redirect_uri"] = $parameters["login_url"];
+            unset($parameters["login_url"]);
+        }
+        $logoutParams = array();
+        if(isset($parameters["logout_url"])){
+            $logoutParams["next"] = $parameters["logout_url"];
+            unset($parameters["logout_url"]);
+        }
+
         return $this->templating->render($name, $parameters + array(
             'async'       => true,
             'fbAsyncInit' => '',
@@ -62,6 +73,8 @@ class FacebookHelper extends Helper
             'cookie'      => true,
             'logging'     => $this->logging,
             'culture'     => $this->culture,
+            'login_url'   => $this->facebook->getLoginUrl($loginParams),
+            'logout_url'   => $this->facebook->getLogoutUrl($logoutParams),
         ));
     }
 


### PR DESCRIPTION
When an AccountStatusException is thrown the AuthenticationProviderManager overrides the ExtraInformation with the token, making impossible to get the uid when handling the exception if the Token doesn't have that information.
