### PR TITLE
Adding the uid to the Token

### DIFF
--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -48,6 +48,7 @@ class FacebookProvider implements AuthenticationProviderInterface
 
         try {
             if ($uid = $this->facebook->getUser()) {
+                $token->setUser($uid);
                 return $this->createAuthenticatedToken($uid);
             }
         } catch (AuthenticationException $failed) {


### PR DESCRIPTION
When a AccountStatusException is thrown the AuthenticationProviderManager overrides the ExtraInformation with the token, making impossible to get the uid when handling the exception if the Token doesn't have that information.
