### PR TITLE
Fix redirect-loop after login

### DIFF
--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -53,7 +53,7 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
                 'display' => $this->options->get('display', 'page'),
                 'fbconnect' => $this->options->get('fbconnect', 1),
                 'req_perms' => implode(',', $this->permissions),
-                'next' => $request->getUriForPath($this->options->get('check_path', '')),
+                'redirect_uri' => $request->getUriForPath($this->options->get('check_path', '')),
             ))
         );
 


### PR DESCRIPTION
Use redirect_uri parameter instead of 'next' (changed in SDK 3.0). 
This fixes a redirect loop when logging in. The redirect loop was caused by the fact that redirect_uri is set to the current url by default, while it should be set to the login check url. 
