### PR TITLE
Session not started when retrieving values

### DIFF
--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -48,6 +48,7 @@ class FacebookSessionPersistence extends \BaseFacebook
      */
     protected function getPersistentData($key, $default = false)
     {
+        $this->session->start();
         return $this->session->get($this->prefix.$key, $default);
     }
 


### PR DESCRIPTION
I think it's related to #49. The FacebookBundle gets initialized before the session is started.
