### PR TITLE
Expose facebook logoutUrl. Expose scope to facebook initialize template.

### DIFF
--- a/Resources/config/facebook.xml
+++ b/Resources/config/facebook.xml
@@ -19,6 +19,7 @@
 
         <service id="fos_facebook.helper" class="%fos_facebook.helper.class%">
             <argument type="service" id="templating" />
+            <argument type="service" id="router" />
             <argument type="service" id="fos_facebook.api" />
             <argument>%fos_facebook.logging%</argument>
             <argument>%fos_facebook.culture%</argument>

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -64,6 +64,7 @@ class FacebookHelper extends Helper
             'cookie'      => true,
             'logging'     => $this->logging,
             'culture'     => $this->culture,
+            'scope'          => implode(',', $this->scope),
         ));
     }
 

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -17,14 +17,16 @@ use Symfony\Component\Templating\EngineInterface;
 class FacebookHelper extends Helper
 {
     protected $templating;
+    protected $router;
     protected $logging;
     protected $culture;
     protected $scope;
     protected $facebook;
 
-    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, $logging = true, $culture = 'en_US', array $scope = array())
+    public function __construct(EngineInterface $templating, $router, \BaseFacebook $facebook, $logging = true, $culture = 'en_US', array $scope = array())
     {
         $this->templating  = $templating;
+        $this->router      = $router;
         $this->logging     = $logging;
         $this->culture     = $culture;
         $this->scope       = $scope;
@@ -72,6 +74,13 @@ class FacebookHelper extends Helper
             'autologoutlink' => 'false',
             'label'          => '',
             'scope'          => implode(',', $this->scope),
+        ));
+    }
+
+    public function getLogoutUrl()
+    {
+        return $this->facebook->getLogoutUrl(array(
+            'next' => $this->router->generate('_security_logout', array(), true)
         ));
     }
 


### PR DESCRIPTION
With an exposed facebook logoutUrl you can simply use this URL as your logout button. It uses the facebook php SDK to generate the url that logs the user out of your facebook app and then redirect to your symfony app's logout URL.

Scope is sometimes needed if you are overriding the initialize template. For example, this is how I perform FB/symfony login (I have found this method to be much more reliable):

```
      <div id="fb_login_button" onclick="fb_login();">Facebook Login</div>
      .... then in facebook initialize ->
       var fb_login = function() {
            FB.login(function(response) {
               if (response.authResponse) {
                 console.log('FB Login Detected');
                 window.location = '{{ path('facebook_security_check') }}';
               } else {
                 console.log('User cancelled login or did not fully authorize.');
               }
            }, {scope: "{{ scope }}"});
        }
```
