### PR TITLE
Handler to erase the fb cookie on the app domain (commits fixed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Installation
                           app_url: "http://apps.facebook.com/appName/"
                           server_url: "http://localhost/facebookApp/"
                       anonymous: true
-                      logout: true
+                      logout:
+                          handlers: ["fos_facebook.logout_handler"]
 
               access_control:
                   - { path: ^/secured/.*, role: [IS_AUTHENTICATED_FULLY] } # This is the route secured with fos_facebook
@@ -169,6 +170,8 @@ Installation
                           default_target_path: /
                           provider: my_fos_facebook_provider
                       anonymous: true
+                      logout:
+                          handlers: ["fos_facebook.logout_handler"]
           
           # application/config/config_dev.yml
           security:
@@ -228,12 +231,22 @@ to the "auth.login" event and then redirect to the "check_path":
 
     <script>
       FB.Event.subscribe('auth.login', function(response) {
-        window.location = {{ path('_security_check') }};
+        window.location = "{{ path('_security_check') }}";
       });
     </script>
 
 The "_security_check" route would need to point to a "/login_check" pattern
 to match the above configuration.
+
+Also, you need to trigger the logout action, so, subscribe the "auth.logout"
+to redirect to the "logout" route:
+
+    <script>
+      FB.Event.subscribe('auth.logout', function(response) {
+        window.location = "{{ path('_security_logout') }}";
+      });
+    </script>
+
 
 Example Customer User Provider using the FOS\UserBundle
 -------------------------------------------------------

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -8,6 +8,10 @@
         <service id="fos_facebook.auth" class="FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider" public="false">
             <argument type="service" id="fos_facebook.api" />
         </service>
+        
+        <service id="fos_facebook.logout_handler" class="FOS\FacebookBundle\Security\Logout\FacebookHandler" public="false">
+            <argument type="service" id="fos_facebook.api" />
+        </service>
 
         <service id="fos_facebook.security.authentication.listener"
                  class="FOS\FacebookBundle\Security\Firewall\FacebookListener"

--- a/Security/Logout/FacebookHandler.php
+++ b/Security/Logout/FacebookHandler.php
@@ -1,0 +1,53 @@
+<?php
+namespace FOS\FacebookBundle\Security\Logout;
+
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Listener for the logout action
+ * 
+ * This handler will erase the cookie keeped by facebook
+ * for the application.
+ * 
+ */
+class FacebookHandler implements LogoutHandlerInterface
+{
+    
+    /**
+     * @var \Facebook $facebookApi
+     */
+    private $facebookApi;
+    
+    /**
+     * __construct
+     * 
+     * @param \Facebook $facebookApi
+     */
+    public function __construct(\BaseFacebook $facebookApi)
+    {
+        $this->facebookApi = $facebookApi;
+    }
+    
+    /**
+     * This method is called by the LogoutListener when a user has requested
+     * to be logged out. Usually, you would unset session variables, or remove
+     * cookies, etc.
+     *
+     * @param Request        $request
+     * @param Response       $response
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        $fb_cookie = sprintf(
+            'fbsr_%d',
+            $this->facebookApi->getAppId()
+        );
+        $response->headers->clearCookie($fb_cookie);
+    }
+    
+}


### PR DESCRIPTION
When the user connect using the facebook, a cookie is written specifically for the application. When the user disconnect, this cookie has not been deleted by the security bundle, which made ​​the javascript sdk remove this cookie and not allowed to connect again, at least until we reloading the page.
This cause me some issues, that was solved with this handler.

Ps.: the cookie name is formed by "fbsr_%app_id%".
