### PR TITLE
fixed: How-to set up the Facebook JavaScript SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ to the "auth.login" event and then redirect to the "check_path":
       function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
-                   setTimeout("goLogIn()",500);
+                   setTimeout(goLogIn,500);
               });
          }
       }
@@ -266,7 +266,7 @@ to redirect to the "logout" route:
       function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
-                   setTimeout("goLogIn()",500);
+                   setTimeout(goLogIn,500);
               });
               FB.Event.subscribe('auth.logout', function(response) {
                    window.location = "{{ path('_security_logout') }}";

--- a/README.md
+++ b/README.md
@@ -275,7 +275,6 @@ to redirect to the "logout" route:
       }
     </script>
 
-NB:
 
 Example Customer User Provider using the FOS\UserBundle
 -------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ the opening `body` tag:
 
       <body>
           <!-- inside a php template -->
-          <?php echo $view['facebook']->initialize(array('xfbml' => true)) ?>
+          <?php echo $view['facebook']->initialize(array('xfbml' => true, 'fbAsyncInit' => 'onfbinit();')) ?>
           <!-- inside a twig template -->
-          {{ facebook_initialize({'xfbml': true}) }}
+          {{ facebook_initialize({'xfbml': true, 'fbAsyncInit': 'onfbinit();'}) }}
 
 If you will be adding XFBML markup to your site you may also declare the
 namespace, perhaps in the opening `html` tag:
@@ -230,9 +230,13 @@ still needs to be triggered. To do this you will in most cases simply subscribe
 to the "auth.login" event and then redirect to the "check_path":
 
     <script>
-      FB.Event.subscribe('auth.login', function(response) {
-        window.location = "{{ path('_security_check') }}";
-      });
+      function onfbinit() {
+         if (typeof(FB) != 'undefined' && FB != null ) {
+              FB.Event.subscribe('auth.login', function(response) {
+                   window.location = "{{ path('_security_check') }}";
+              });
+         }
+      }
     </script>
 
 The "_security_check" route would need to point to a "/login_check" pattern
@@ -242,9 +246,16 @@ Also, you need to trigger the logout action, so, subscribe the "auth.logout"
 to redirect to the "logout" route:
 
     <script>
-      FB.Event.subscribe('auth.logout', function(response) {
-        window.location = "{{ path('_security_logout') }}";
-      });
+      function onfbinit() {
+         if (typeof(FB) != 'undefined' && FB != null ) {
+              FB.Event.subscribe('auth.login', function(response) {
+                   window.location = "{{ path('_security_check') }}";
+              });
+              FB.Event.subscribe('auth.logout', function(response) {
+                   window.location = "{{ path('_security_logout') }}";
+              });
+         }
+      }
     </script>
 
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ the opening `body` tag:
 
       <body>
           <!-- inside a php template -->
-          <?php echo $view['facebook']->initialize(array('xfbml' => true, 'fbAsyncInit' => 'onfbinit();')) ?>
+          <?php echo $view['facebook']->initialize(array('xfbml' => true, 'fbAsyncInit' => 'onFbInit();')) ?>
           <!-- inside a twig template -->
-          {{ facebook_initialize({'xfbml': true, 'fbAsyncInit': 'onfbinit();'}) }}
+          {{ facebook_initialize({'xfbml': true, 'fbAsyncInit': 'onFbInit();'}) }}
 
 If you will be adding XFBML markup to your site you may also declare the
 namespace, perhaps in the opening `html` tag:
@@ -230,7 +230,7 @@ still needs to be triggered. To do this you will in most cases simply subscribe
 to the "auth.login" event and then redirect to the "check_path":
 
     <script>
-      function onfbinit() {
+      function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
                    window.location = "{{ path('_security_check') }}";
@@ -246,7 +246,7 @@ Also, you need to trigger the logout action, so, subscribe the "auth.logout"
 to redirect to the "logout" route:
 
     <script>
-      function onfbinit() {
+      function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
                    window.location = "{{ path('_security_check') }}";

--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ the opening `body` tag:
           <!-- inside a twig template -->
           {{ facebook_initialize({'xfbml': true, 'fbAsyncInit': 'onFbInit();'}) }}
 
+Note that `fbAsyncInit` is a parameter helping you to execute JavaScript within 
+the function initializing the connection with Facebook, just after the `FB.init();`
+call. `onFbInit();` is a JavaScript function defined furthermore to execute functions
+which need `FB` initialized.
+
 If you will be adding XFBML markup to your site you may also declare the
 namespace, perhaps in the opening `html` tag:
 
@@ -230,14 +235,22 @@ still needs to be triggered. To do this you will in most cases simply subscribe
 to the "auth.login" event and then redirect to the "check_path":
 
     <script>
+      function goLogIn(){
+          window.location = "{{ path('_security_check') }}";
+      }
+    
       function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
-                   window.location = "{{ path('_security_check') }}";
+                   setTimeout("goLogIn()",500);
               });
          }
       }
     </script>
+    
+Note that we wait 500ms before redirecting to let the browser dealing with the 
+Facebook cookie. You can avoid this step but you might get this error message:
+*"The Facebook user could not be retrieved from the session."*
 
 The "_security_check" route would need to point to a "/login_check" pattern
 to match the above configuration.
@@ -246,10 +259,14 @@ Also, you need to trigger the logout action, so, subscribe the "auth.logout"
 to redirect to the "logout" route:
 
     <script>
+      function goLogIn(){
+          window.location = "{{ path('_security_check') }}";
+      }
+    
       function onFbInit() {
          if (typeof(FB) != 'undefined' && FB != null ) {
               FB.Event.subscribe('auth.login', function(response) {
-                   window.location = "{{ path('_security_check') }}";
+                   setTimeout("goLogIn()",500);
               });
               FB.Event.subscribe('auth.logout', function(response) {
                    window.location = "{{ path('_security_logout') }}";
@@ -258,6 +275,7 @@ to redirect to the "logout" route:
       }
     </script>
 
+NB:
 
 Example Customer User Provider using the FOS\UserBundle
 -------------------------------------------------------


### PR DESCRIPTION
This PR is fixing the PR **"Fb event subscribe fix"** by updating the **README.md** with better explainations:
https://github.com/FriendsOfSymfony/FOSFacebookBundle/pull/36

The common error was (I had this too, that's why I wanted to fix it):
_The result is following javascript error message (Firefox 4): "FB is not defined"._

The error was to use <pre>{{ facebook_initialize({'xfbml': true}) }}</pre> when we should use <pre>{{ facebook_initialize({'xfbml': true, 'fbAsyncInit': 'onfbinit();'}) }}</pre>

with this Javascript script:

<pre>
function onfbinit() {
     if (typeof(FB) != 'undefined' && FB != null ) {
          FB.Event.subscribe('auth.login', function(response) {
               window.location = "{{ path('_security_check') }}";
          });
          FB.Event.subscribe('auth.logout', function(response) {
               window.location = "{{ path('_security_logout') }}";
     });
     }
}
</pre>


The thing is : everytime you call "FB" in Javascript it requires FB.init() done. So each call of "FB" functions has to be called just after FB.init() and within the same function. This can be done through the parameter **fbAsyncInit**
