### PR TITLE
refreshUser method in FacebookProvider : There is no user provider for user "Acme\DemoBundle\Entity\User"

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ to the provider id in the "provider" section in the config.yml:
 
         public function refreshUser(UserInterface $user)
         {
+        
+            $user->setFacebookId($user->getUsername()); 
+        
             if (!$this->supportsClass(get_class($user)) || !$user->getFacebookId()) {
                 throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
             }

--- a/README.md
+++ b/README.md
@@ -365,9 +365,6 @@ to the provider id in the "provider" section in the config.yml:
 
         public function refreshUser(UserInterface $user)
         {
-        
-            $user->setFacebookId($user->getUsername()); 
-        
             if (!$this->supportsClass(get_class($user)) || !$user->getFacebookId()) {
                 throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
             }
@@ -401,6 +398,20 @@ The following example also adds "firstname" and "lastname" properties:
          * @var string
          */
         protected $facebookID;
+
+
+        public function serialize()
+        {
+            return serialize(array($this->facebookId, parent::serialize()));
+        }
+
+        public function unserialize($data)
+        {
+            list($this->facebookId, $parentData) = unserialize($data);
+            parent::unserialize($parentData);
+        }
+
+
 
         /**
          * @return string


### PR DESCRIPTION
After following all the instructions from FOSUserBundle and FOSFacebookBundle to set up an external facebook auth that triggers symfony security mechanism, I ended up with the error :

> There is no user provider for user "Acme\DemoBundle\Entity\User".  

when accessing /login_check (redirected from facebook.com)
The exception was thrown in the refreshUser method.

It seemed that at this point, $user had a username but no facebookId. Adding the proposed line solves the issue.
(but is it the good way to solve it ?...)
