### PR TITLE
Update Security/Authentication/Provider/FacebookProvider.php

### DIFF
--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -108,6 +108,6 @@ class FacebookProvider implements AuthenticationProviderInterface
             throw new \RuntimeException('User provider did not return an implementation of user interface.');
         }
 
-        return new FacebookUserToken($user, $user->getRoles());
+        return new FacebookUserToken($user->getFacebookId(), $user->getRoles());
     }
 }


### PR DESCRIPTION
The constructor for FOS\FacebookBundle\Security\Authentication\Token\FacebookUserToken takes a UID, not a user object.

class FacebookUserToken extends AbstractToken
{
    public function __construct($uid = '', array $roles = array()) 
    { 
        ...
