### PR TITLE
facebook_login_url()

### DIFF
--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -77,6 +77,20 @@ class FacebookHelper extends Helper
         ));
     }
 
+    public function loginUrl($parameters = array())
+    {
+        if (!isset($parameters['scope'])) {
+            $parameters['scope'] = implode(',', $this->scope);
+        }
+
+        // // todo: default to the configured check_path
+        // if (!isset($parameters['redirect_uri'])) {
+        //     $parameters['redirect_uri'] =
+        // }
+
+        return $this->facebook->getLoginUrl($parameters);
+    }
+
     /**
      * @codeCoverageIgnore
      */

--- a/Tests/Twig/Extension/FacebookExtensionTest.php
+++ b/Tests/Twig/Extension/FacebookExtensionTest.php
@@ -12,7 +12,7 @@
 namespace FOS\FacebookBundle\Tests\Twig\Extension;
 
 use FOS\FacebookBundle\Twig\Extension\FacebookExtension;
-use FOS\FacebookBundle\Templating\Helper\FacebookHelper;
+use Symfony\Component\DependencyInjection\Container;
 
 class FacebookExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -78,5 +78,26 @@ class FacebookExtensionTest extends \PHPUnit_Framework_TestCase
  
         $extension = new FacebookExtension($containerMock);
         $this->assertSame('returnedValueLogin', $extension->renderLoginButton());
+    }
+
+    /**
+     * @covers FOS\FacebookBundle\Twig\Extension\FacebookExtension::getLoginUrl
+     */
+    public function testGetLoginUrl()
+    {
+        $helper = $this->getMockBuilder('FOS\FacebookBundle\Templating\Helper\FacebookHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container = new Container();
+        $container->set('fos_facebook.helper', $helper);
+
+        $helper->expects($this->once())
+            ->method('loginUrl')
+            ->with(array('foo' => 'bar'))
+            ->will($this->returnValue('http://foo.com'));
+
+        $extension = new FacebookExtension($container);
+        $this->assertEquals('http://foo.com', $extension->getLoginUrl(array('foo' => 'bar')));
     }
 }

--- a/Twig/Extension/FacebookExtension.php
+++ b/Twig/Extension/FacebookExtension.php
@@ -36,8 +36,9 @@ class FacebookExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'facebook_initialize' => new \Twig_Function_Method($this, 'renderInitialize', array('is_safe' => array('html'))),
+            'facebook_initialize'   => new \Twig_Function_Method($this, 'renderInitialize', array('is_safe' => array('html'))),
             'facebook_login_button' => new \Twig_Function_Method($this, 'renderLoginButton', array('is_safe' => array('html'))),
+            'facebook_login_url'    => new \Twig_Function_Method($this, 'getLoginUrl'),
         );
     }
 
@@ -65,5 +66,13 @@ class FacebookExtension extends \Twig_Extension
     public function renderLoginButton($parameters = array(), $name = null)
     {
         return $this->container->get('fos_facebook.helper')->loginButton($parameters, $name ?: 'FOSFacebookBundle::loginButton.html.twig');
+    }
+
+    /**
+     * @see FacebookHelper::loginUrl()
+     */
+    public function getLoginUrl($parameters = array())
+    {
+        return $this->container->get('fos_facebook.helper')->loginUrl($parameters);
     }
 }


### PR DESCRIPTION
This adds a function to return the Facebook login URL. This is handy if you are using the Javascript SDK but want a hard-coded href in place in case Javascript is off.
