### PR TITLE
Fix session init issue #79

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('class')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('api')->defaultValue('FOS\FacebookBundle\Facebook\FacebookSessionPersistence')->end()
+                        ->scalarNode('api')->defaultValue('FOS\FacebookBundle\Facebook\FacebookSessionPersistenceProxy')->end()
                         ->scalarNode('helper')->defaultValue('FOS\FacebookBundle\Templating\Helper\FacebookHelper')->end()
                         ->scalarNode('twig')->defaultValue('FOS\FacebookBundle\Twig\Extension\FacebookExtension')->end()
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('class')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('api')->defaultValue('FOS\FacebookBundle\Facebook\FacebookSessionPersistenceProxy')->end()
+                        ->scalarNode('api')->defaultValue('FOS\FacebookBundle\Facebook\FacebookSessionPersistence')->end()
                         ->scalarNode('helper')->defaultValue('FOS\FacebookBundle\Templating\Helper\FacebookHelper')->end()
                         ->scalarNode('twig')->defaultValue('FOS\FacebookBundle\Twig\Extension\FacebookExtension')->end()
                     ->end()

--- a/Facebook/FacebookInterface.php
+++ b/Facebook/FacebookInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FOS\FacebookBundle\Facebook;
+
+interface FacebookInterface
+{
+    function getUser();
+    function getAppId();
+    function setAppId($appId);
+    function getAppSecret();
+    function setAppSecret($secret);
+    function getApiSecret();
+    function setApiSecret($secret);
+    function setFileUploadSupport($supported);
+    function getFileUploadSupport();
+    function getAccessToken();
+    function setAccessToken($token);
+    function getSignedRequest();
+    function getLoginUrl($params = array());
+    function getLogoutUrl($params = array());
+    function getLoginStatusUrl($params = array());
+    function api();
+    function destroySession();
+}

--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -63,7 +63,7 @@ class FacebookSessionPersistence extends \BaseFacebook
             self::errorLog('Unsupported key passed to getPersistentData.');
             return $default;
         }
-        
+
         $sessionVariableName = $this->constructSessionVariableName($key);
         if ($this->session->has($sessionVariableName)) {
             return $this->session->get($sessionVariableName);

--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Session;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class FacebookSessionPersistence extends \BaseFacebook
+class FacebookSessionPersistence extends \BaseFacebook implements FacebookInterface
 {
     const PREFIX = '_fos_facebook_';
 

--- a/Facebook/FacebookSessionPersistenceProxy.php
+++ b/Facebook/FacebookSessionPersistenceProxy.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace FOS\FacebookBundle\Facebook;
+
+use Symfony\Component\HttpFoundation\Session;
+
+/**
+ * @author Leszek Prabucki <leszek.prabucki@gmail.com>
+ */
+class FacebookSessionPersistenceProxy
+{
+    /**
+     * @var Symfony\Component\HttpFoundation\Session
+     */
+    protected $session = null;
+
+    /**
+     * @var string
+     */
+    protected $prefix = '';
+
+    /**
+     * @var array
+     */
+    protected $config = array();
+
+    /**
+     * @var FOS\FacebookBundle\Facebook\FacebookSessionPersistence
+     */
+    private $sessionPersistence = null;
+
+   /**
+    * @param array $config the application configuration.
+    * @param Symfony\Component\HttpFoundation\Session
+    * @param string
+    */
+    public function __construct($config, Session $session, $prefix = null)
+    {
+        $this->config  = $config;
+        $this->session = $session;
+        $this->prefix  = $prefix;
+    }
+
+    public function getUser()
+    {
+        return $this->getSessionPersistence()->getUser();
+    }
+
+    public function getAppId()
+    {
+        return $this->getSessionPersistence()->getAppId();
+    }
+
+    public function setAppId($appId)
+    {
+        return $this->getSessionPersistence()->setAppId($appId);
+    }
+
+    public function getAppSecret()
+    {
+        return $this->getSessionPersistence()->getAppSecret();
+    }
+
+    public function setAppSecret($secret)
+    {
+        return $this->getSessionPersistence()->setAppSecret($secret);
+    }
+
+    public function getApiSecret()
+    {
+        return $this->getSessionPersistence()->getApiSecret();
+    }
+
+    public function setApiSecret($secret)
+    {
+        return $this->getSessionPersistence()->setApiSecret($secret);
+    }
+
+    public function setFileUploadSupport($supported)
+    {
+        return $this->getSessionPersistence()->setFileUploadSupport($supported);
+    }
+
+    public function getFileUploadSupport()
+    {
+        return $this->getSessionPersistence()->getFileUploadSupport();
+    }
+
+    public function useFileUploadSupport()
+    {
+        return $this->getSessionPersistence()->useFileUploadSupport();
+    }
+
+    public function getAccessToken()
+    {
+        return $this->getSessionPersistence()->getAccessToken();
+    }
+
+    public function setAccessToken($token)
+    {
+        return $this->getSessionPersistence()->setAccessToken($token);
+    }
+
+    public function getSignedRequest()
+    {
+        return $this->getSessionPersistence()->getSignedRequest();
+    }
+
+    public function getLoginUrl($params = array())
+    {
+        return $this->getSessionPersistence()->getLoginUrl($params);
+    }
+
+    public function getLogoutUrl($params = array())
+    {
+        return $this->getSessionPersistence()->getLogoutUrl($params);
+    }
+
+    public function getLoginStatusUrl($params = array())
+    {
+        return $this->getSessionPersistence()->getLoginStatusUrl($params);
+    }
+
+    public function api()
+    {
+        $args = func_get_args();
+
+        return $this->getSessionPersistence()->api($args);
+    }
+
+    public function destroySession()
+    {
+        return $this->getSessionPersistence()->destroySession();
+    }
+
+    /**
+     * @return FOS\FacebookBundle\Facebook\FacebookSessionPersistence
+     */
+    protected function getSessionPersistence()
+    {
+        if (!$this->sessionPersistence) {
+            $this->sessionPersistence = $this->createSessionPersistence();
+        }
+
+        return $this->sessionPersistence;
+    }
+
+    /**
+     * @return FOS\FacebookBundle\Facebook\FacebookSessionPersistence
+     */
+    protected function createSessionPersistence()
+    {
+        return new FacebookSessionPersistence($this->config, $this->session, $this->prefix);
+    }
+}

--- a/Facebook/FacebookSessionPersistenceProxy.php
+++ b/Facebook/FacebookSessionPersistenceProxy.php
@@ -125,12 +125,17 @@ class FacebookSessionPersistenceProxy implements FacebookInterface
     {
         $args = func_get_args();
 
-        return $this->getSessionPersistence()->api($args);
+        return call_user_func_array(array($this->getSessionPersistence(), 'api'), $args);
     }
 
     public function destroySession()
     {
         return $this->getSessionPersistence()->destroySession();
+    }
+
+    public function setSessionPersistence(FacebookInterface $sessionPersistence)
+    {
+        $this->sessionPersistence = $sessionPersistence;
     }
 
     /**

--- a/Facebook/FacebookSessionPersistenceProxy.php
+++ b/Facebook/FacebookSessionPersistenceProxy.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Session;
 /**
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
  */
-class FacebookSessionPersistenceProxy
+class FacebookSessionPersistenceProxy implements FacebookInterface
 {
     /**
      * @var Symfony\Component\HttpFoundation\Session

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -8,7 +8,7 @@
         <service id="fos_facebook.auth" class="FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider" public="false">
             <argument type="service" id="fos_facebook.api" />
         </service>
-        
+
         <service id="fos_facebook.logout_handler" class="FOS\FacebookBundle\Security\Logout\FacebookHandler" public="false">
             <argument type="service" id="fos_facebook.api" />
         </service>

--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -23,18 +23,19 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 
 use FOS\FacebookBundle\Security\Authentication\Token\FacebookUserToken;
+use FOS\FacebookBundle\Facebook\FacebookInterface;
 
 class FacebookProvider implements AuthenticationProviderInterface
 {
     /**
-     * @var \BaseFacebook
+     * @var FOS\FacebookBundle\Facebook\FacebookInterface
      */
     protected $facebook;
     protected $userProvider;
     protected $userChecker;
     protected $createIfNotExists;
 
-    public function __construct(\BaseFacebook $facebook, UserProviderInterface $userProvider = null, UserCheckerInterface $userChecker = null, $createIfNotExists = false)
+    public function __construct(FacebookInterface $facebook, UserProviderInterface $userProvider = null, UserCheckerInterface $userChecker = null, $createIfNotExists = false)
     {
         if (null !== $userProvider && null === $userChecker) {
             throw new \InvalidArgumentException('$userChecker cannot be null, if $userProvider is not null.');

--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
+use FOS\FacebookBundle\Facebook\FacebookInterface;
+
 /**
  * FacebookAuthenticationEntryPoint starts an authentication via Facebook.
  *
@@ -32,10 +34,10 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
     /**
      * Constructor
      *
-     * @param BaseFacebook $facebook
+     * @param FOS\FacebookBundle\Facebook\FacebookInterface $facebook
      * @param array    $options
      */
-    public function __construct(\BaseFacebook $facebook, array $options = array(), array $permissions = array())
+    public function __construct(FacebookInterface $facebook, array $options = array(), array $permissions = array())
     {
         $this->facebook = $facebook;
         $this->permissions = $permissions;

--- a/Security/Logout/FacebookHandler.php
+++ b/Security/Logout/FacebookHandler.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 
+use FOS\FacebookBundle\Facebook\FacebookInterface;
+
 /**
  * Listener for the logout action
  *
@@ -25,7 +27,7 @@ class FacebookHandler implements LogoutHandlerInterface
 {
     private $facebook;
 
-    public function __construct(\BaseFacebook $facebook)
+    public function __construct(FacebookInterface $facebook)
     {
         $this->facebook = $facebook;
     }

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -14,6 +14,8 @@ namespace FOS\FacebookBundle\Templating\Helper;
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Templating\EngineInterface;
 
+use FOS\FacebookBundle\Facebook\FacebookInterface;
+
 class FacebookHelper extends Helper
 {
     protected $templating;
@@ -22,7 +24,7 @@ class FacebookHelper extends Helper
     protected $scope;
     protected $facebook;
 
-    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, $logging = true, $culture = 'en_US', array $scope = array())
+    public function __construct(EngineInterface $templating, FacebookInterface $facebook, $logging = true, $culture = 'en_US', array $scope = array())
     {
         $this->templating  = $templating;
         $this->logging     = $logging;

--- a/Tests/Facebook/FacebookSessionPersistenceProxyTest.php
+++ b/Tests/Facebook/FacebookSessionPersistenceProxyTest.php
@@ -12,24 +12,35 @@
 namespace FOS\FacebookBundle\Tests\Facebook;
 
 use FOS\FacebookBundle\Facebook\FacebookSessionPersistenceProxy;
-use FOS\FacebookBundle\Facebook\FacebookSessionPersistence;
 
 class FacebookSessionPersistenceProxyTest extends \PHPUnit_Framework_TestCase
 {
     public function testThatCanSetAppId()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $this->assertEquals('234', $facebook->getAppId());
         $facebook->setAppId('345');
-        $this->assertEquals('345', $facebook->getAppId());
+    }
+
+    public function testThatCanMakeApiQuery()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('aa'), $this->equalTo(1), $this->equalTo(2))
+            ->will($this->returnValue('api call'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('api call', $facebookProxy->api('aa', 1, 2));
     }
 
     public function testThatCanSetApiSecret()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $this->assertEquals('secret', $facebook->getApiSecret());
         $facebook->setApiSecret('secret1');
@@ -38,8 +49,7 @@ class FacebookSessionPersistenceProxyTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetAppSecret()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $facebook->setAppSecret('secret2');
         $this->assertEquals('secret2', $facebook->getAppSecret());
@@ -47,11 +57,18 @@ class FacebookSessionPersistenceProxyTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetFileUploadSupport()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $facebook->setFileUploadSupport(true);
         $this->assertEquals(true, $facebook->getFileUploadSupport());
+    }
+
+    public function testThatCanCheckIfUseFileUploadSupport()
+    {
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook->setFileUploadSupport(true);
+        $this->assertEquals(true, $facebook->useFileUploadSupport());
     }
 
     public function testThatCanSetAccessToken()
@@ -65,6 +82,92 @@ class FacebookSessionPersistenceProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('234|secret', $facebook->getAccessToken());
         $facebook->setAccessToken('token1');
         $this->assertEquals('token1', $facebook->getAccessToken());
+    }
+
+    public function testThatCanGetSignedRequest()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('getSignedRequest')
+            ->will($this->returnValue('signed request'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('signed request', $facebookProxy->getSignedRequest());
+    }
+
+    public function testThatCanGetLogoutUrl()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('getLogoutUrl')
+            ->with($this->equalTo(array('test' => '123')))
+            ->will($this->returnValue('http://logout'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('http://logout', $facebookProxy->getLogoutUrl(array('test' => '123')));
+    }
+
+    public function testThatCanGetLoginUrl()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('getLoginUrl')
+            ->with($this->equalTo(array('test' => '123')))
+            ->will($this->returnValue('http://login'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('http://login', $facebookProxy->getLoginUrl(array('test' => '123')));
+    }
+
+    public function testThatCanGetUser()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue('user from facebook'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('user from facebook', $facebookProxy->getUser());
+    }
+
+    public function testThatCanDestroySession()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('destroySession');
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $facebookProxy->destroySession();
+    }
+
+    public function testThatCanGetLoginStatusUrl()
+    {
+        $facebookProxy = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
+
+        $facebook = $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
+        $facebook->expects($this->once())
+            ->method('getLoginStatusUrl')
+            ->with($this->equalTo(array('test' => '123')))
+            ->will($this->returnValue('http://login'));
+
+        $facebookProxy->setSessionPersistence($facebook);
+
+        $this->assertEquals('http://login', $facebookProxy->getLoginStatusUrl(array('test' => '123')));
     }
 
     public function testThatCanGetAccessToken()

--- a/Tests/Facebook/FacebookSessionPersistenceProxyTest.php
+++ b/Tests/Facebook/FacebookSessionPersistenceProxyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the FOSFacebookBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\FacebookBundle\Tests\Facebook;
+
+use FOS\FacebookBundle\Facebook\FacebookSessionPersistenceProxy;
+use FOS\FacebookBundle\Facebook\FacebookSessionPersistence;
+
+class FacebookSessionPersistenceProxyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatCanSetAppId()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('234', $facebook->getAppId());
+        $facebook->setAppId('345');
+        $this->assertEquals('345', $facebook->getAppId());
+    }
+
+    public function testThatCanSetApiSecret()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('secret', $facebook->getApiSecret());
+        $facebook->setApiSecret('secret1');
+        $this->assertEquals('secret1', $facebook->getApiSecret());
+    }
+
+    public function testThatCanSetAppSecret()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $facebook->setAppSecret('secret2');
+        $this->assertEquals('secret2', $facebook->getAppSecret());
+    }
+
+    public function testThatCanSetFileUploadSupport()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $facebook->setFileUploadSupport(true);
+        $this->assertEquals(true, $facebook->getFileUploadSupport());
+    }
+
+    public function testThatCanSetAccessToken()
+    {
+        $session = $this->getSession();
+        $session->expects($this->any())
+            ->method('all')
+            ->will($this->returnValue(array('1', '_fos_facebook_123' => 'test')));
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('234|secret', $facebook->getAccessToken());
+        $facebook->setAccessToken('token1');
+        $this->assertEquals('token1', $facebook->getAccessToken());
+    }
+
+    public function testThatCanGetAccessToken()
+    {
+        $session = $this->getSession();
+        $session->expects($this->any())
+            ->method('all')
+            ->will($this->returnValue(array()));
+        $session->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(array(true)));
+        $session->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue('state'));
+        $facebook = new FacebookSessionPersistenceProxy(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $_REQUEST['code'] = '123';
+        $_REQUEST['state'] = 'state';
+        $_SERVER['HTTP_HOST'] = 'http://localhost';
+        $_SERVER['REQUEST_URI'] = 'index.php';
+
+        $this->assertEquals('234|secret', $facebook->getAccessToken());
+    }
+
+    private function getSession()
+    {
+        return $this->getMockBuilder('Symfony\Component\HttpFoundation\Session')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/Tests/Facebook/FacebookSessionPersistenceTest.php
+++ b/Tests/Facebook/FacebookSessionPersistenceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the FOSFacebookBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\FacebookBundle\Tests\Facebook;
+
+use FOS\FacebookBundle\Facebook\FacebookSessionPersistence;
+
+class FacebookSessionPersistenceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatGetUserSaveUserInSession()
+    {
+        $session = $this->getSession();
+        $session->expects($this->any())
+            ->method('set')
+            ->with($this->equalTo('_fos_facebook_fb_234_user_id'), $this->equalTo('123456789'));
+
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('123456789', $facebook->getUser());
+    }
+
+    public function testThatCanSetAppId()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('234', $facebook->getAppId());
+        $facebook->setAppId('345');
+        $this->assertEquals('345', $facebook->getAppId());
+    }
+
+    public function testThatCanSetApiSecret()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('secret', $facebook->getApiSecret());
+        $facebook->setApiSecret('secret1');
+        $this->assertEquals('secret1', $facebook->getApiSecret());
+    }
+
+    public function testThatCanSetAppSecret()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $facebook->setAppSecret('secret2');
+        $this->assertEquals('secret2', $facebook->getAppSecret());
+    }
+
+    public function testThatCanSetFileUploadSupport()
+    {
+        $session = $this->getSession();
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $facebook->setFileUploadSupport(true);
+        $this->assertEquals(true, $facebook->getFileUploadSupport());
+    }
+
+    public function testThatCanSetAccessToken()
+    {
+        $session = $this->getSession();
+        $session->expects($this->any())
+            ->method('all')
+            ->will($this->returnValue(array('1', '_fos_facebook_123' => 'test')));
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $this->assertEquals('234|secret', $facebook->getAccessToken());
+        $facebook->setAccessToken('token1');
+        $this->assertEquals('token1', $facebook->getAccessToken());
+    }
+
+    public function testThatCanGetAccessToken()
+    {
+        $session = $this->getSession();
+        $session->expects($this->any())
+            ->method('all')
+            ->will($this->returnValue(array()));
+        $session->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(array(true)));
+        $session->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue('state'));
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+
+        $facebook->signedRequest = false;
+        $_REQUEST['code'] = '123';
+        $_REQUEST['state'] = 'state';
+        $this->assertEquals('234|secret', $facebook->getAccessToken());
+    }
+
+    private function getSession()
+    {
+        return $this->getMockBuilder('Symfony\Component\HttpFoundation\Session')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}
+
+class FacebookSessionPersistenceStub extends FacebookSessionPersistence
+{
+    public $signedRequest = array(
+        'user_id' => '123456789'
+    );
+
+    public function getSignedRequest()
+    {
+        return $this->signedRequest;
+    }
+
+    public function getCurrentUrl()
+    {
+        return 'http://localhost';
+    }
+}

--- a/Tests/Facebook/FacebookSessionPersistenceTest.php
+++ b/Tests/Facebook/FacebookSessionPersistenceTest.php
@@ -29,8 +29,7 @@ class FacebookSessionPersistenceTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetAppId()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $this->assertEquals('234', $facebook->getAppId());
         $facebook->setAppId('345');
@@ -39,8 +38,7 @@ class FacebookSessionPersistenceTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetApiSecret()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $this->assertEquals('secret', $facebook->getApiSecret());
         $facebook->setApiSecret('secret1');
@@ -49,8 +47,7 @@ class FacebookSessionPersistenceTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetAppSecret()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $facebook->setAppSecret('secret2');
         $this->assertEquals('secret2', $facebook->getAppSecret());
@@ -58,8 +55,7 @@ class FacebookSessionPersistenceTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCanSetFileUploadSupport()
     {
-        $session = $this->getSession();
-        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $session);
+        $facebook = new FacebookSessionPersistenceStub(array('appId' => '234', 'secret' => 'secret'), $this->getSession());
 
         $facebook->setFileUploadSupport(true);
         $this->assertEquals(true, $facebook->getFileUploadSupport());

--- a/Tests/Security/Authentication/Provider/FacebookProviderTest.php
+++ b/Tests/Security/Authentication/Provider/FacebookProviderTest.php
@@ -21,7 +21,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatUserCheckerCannotBeNullWhenUserProviderIsNotNull()
     {
-        $facebookProvider = new FacebookProvider($this->getMock('\BaseFacebook'), $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface'));
+        $facebookProvider = new FacebookProvider($this->getFacebook(), $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface'));
     }
 
     /**
@@ -29,7 +29,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCannotAuthenticateWhenTokenIsNotFacebookUserToken()
     {
-        $facebookProvider = new FacebookProvider($this->getMock('\BaseFacebook'));
+        $facebookProvider = new FacebookProvider($this->getFacebook());
         $this->assertNull($facebookProvider->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')));
     }
 
@@ -39,7 +39,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCanAuthenticateUserWithoutUserProvider()
     {
-        $facebookMock = $this->getMock('\BaseFacebook', array('getUser'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue('123'));
@@ -58,7 +58,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCannotAuthenticateWhenUserProviderThrowsAuthenticationException()
     {
-        $facebookMock = $this->getMock('\BaseFacebook', array('getUser'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue('123'));
@@ -81,7 +81,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCannotAuthenticateWhenUserProviderDoesNotReturnUsetInterface()
     {
-        $facebookMock = $this->getMock('\BaseFacebook', array('getUser'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue('123'));
@@ -104,7 +104,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCannotAuthenticateWhenCannotRetrieveFacebookUserFromSession()
     {
-        $facebookMock = $this->getMock('\BaseFacebook', array('getUser'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue(false));
@@ -131,7 +131,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
             ->method('getRoles')
             ->will($this->returnValue(array()));
 
-        $facebookMock = $this->getMock('\BaseFacebook', array('getUser'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getUser')
             ->will($this->returnValue('123'));
@@ -153,5 +153,19 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
 
         $facebookProvider = new FacebookProvider($facebookMock, $userProviderMock, $userCheckerMock);
         $this->assertEquals('l3l0', $facebookProvider->authenticate($tokenMock)->getUsername());
+    }
+
+    private function getFacebook()
+    {
+        return $this->getMockBuilder('\BaseFacebook')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getUser',
+                'clearAllPersistentData',
+                'getPersistentData',
+                'clearPersistentData',
+                'setPersistentData'
+            ))
+            ->getMock();
     }
 }

--- a/Tests/Security/Authentication/Provider/FacebookProviderTest.php
+++ b/Tests/Security/Authentication/Provider/FacebookProviderTest.php
@@ -157,15 +157,6 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
 
     private function getFacebook()
     {
-        return $this->getMockBuilder('\BaseFacebook')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getUser',
-                'clearAllPersistentData',
-                'getPersistentData',
-                'clearPersistentData',
-                'setPersistentData'
-            ))
-            ->getMock();
+        return $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
     }
 }

--- a/Tests/Security/EntryPoint/FacebookAuthenticationEntryPointTest.php
+++ b/Tests/Security/EntryPoint/FacebookAuthenticationEntryPointTest.php
@@ -66,15 +66,6 @@ class FacebookAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 
     private function getFacebook()
     {
-        return $this->getMockBuilder('\BaseFacebook')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getLoginUrl',
-                'clearAllPersistentData',
-                'getPersistentData',
-                'clearPersistentData',
-                'setPersistentData'
-            ))
-            ->getMock();
+        return $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
     }
 }

--- a/Tests/Security/EntryPoint/FacebookAuthenticationEntryPointTest.php
+++ b/Tests/Security/EntryPoint/FacebookAuthenticationEntryPointTest.php
@@ -27,7 +27,7 @@ class FacebookAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('http://localhost/index'));
 
         $options = array('check_path' => '/index');
-        $facebookMock = $this->getMock('\BaseFacebook', array('getLoginUrl'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getLoginUrl')
             ->with($this->equalTo(array(
@@ -52,7 +52,7 @@ class FacebookAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
         $requestMock = $this->getMock('Symfony\Component\HttpFoundation\Request', array('getUriForPath'));
 
         $options = array('check_path' => '/index', 'server_url' => 'http://server.url', 'app_url' => 'http://app.url');
-        $facebookMock = $this->getMock('\BaseFacebook', array('getLoginUrl'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getLoginUrl')
             ->will($this->returnValue('http://localhost/facebook-redirect/index'));
@@ -62,5 +62,19 @@ class FacebookAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'Response is returned');
         $this->assertRegExp('/location\.href="http:\/\/localhost\/facebook-redirect\/index/', $response->getContent(), 'Javascript redirection is in response');
+    }
+
+    private function getFacebook()
+    {
+        return $this->getMockBuilder('\BaseFacebook')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getLoginUrl',
+                'clearAllPersistentData',
+                'getPersistentData',
+                'clearPersistentData',
+                'setPersistentData'
+            ))
+            ->getMock();
     }
 }

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -80,15 +80,6 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
 
     private function getFacebook()
     {
-        return $this->getMockBuilder('\BaseFacebook')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getAppId',
-                'clearAllPersistentData',
-                'getPersistentData',
-                'clearPersistentData',
-                'setPersistentData'
-            ))
-            ->getMock();
+        return $this->getMock('FOS\FacebookBundle\Facebook\FacebookInterface');
     }
 }

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -17,6 +17,7 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @covers FOS\FacebookBundle\Templating\Helper\FacebookHelper::initialize
+     * @covers FOS\FacebookBundle\Templating\Helper\FacebookHelper::__construct
      */
     public function testInitialize()
     {

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -41,7 +41,7 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->once())
             ->method('getAppId')
             ->will($this->returnValue('123'));
@@ -70,11 +70,25 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
+        $facebookMock = $this->getFacebook();
         $facebookMock->expects($this->any())
             ->method('getAppId');
 
         $helper = new FacebookHelper($templating, $facebookMock, true, 'en_US', array(1,2,3) );
         $this->assertSame($expected, $helper->loginButton(array('label' => 'testLabel')));
+    }
+
+    private function getFacebook()
+    {
+        return $this->getMockBuilder('\BaseFacebook')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getAppId',
+                'clearAllPersistentData',
+                'getPersistentData',
+                'clearPersistentData',
+                'setPersistentData'
+            ))
+            ->getMock();
     }
 }

--- a/Tests/Twig/Extension/FacebookExtensionTest.php
+++ b/Tests/Twig/Extension/FacebookExtensionTest.php
@@ -18,6 +18,7 @@ class FacebookExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @covers FOS\FacebookBundle\Twig\Extension\FacebookExtension::getName
+     * @covers FOS\FacebookBundle\Twig\Extension\FacebookExtension::__construct
      */
     public function testGetName()
     {

--- a/Tests/autoload.php.dist
+++ b/Tests/autoload.php.dist
@@ -23,6 +23,8 @@ $loader->registerPrefixes(array(
 ));
 $loader->register();
 
+include_once $vendorDir . '/facebook/src/base_facebook.php';
+
 spl_autoload_register(function($class) {
     if (0 === strpos($class, 'FOS\\FacebookBundle\\')) {
         $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 2)).'.php';


### PR DESCRIPTION
It is how I to handled issue #79

For test env we can use FOS\FacebookBundle\Facebook\FacebookSessionPersistenceProxy which will construct FOS\FacebookBundle\Facebook\FacebookSessionPersistence object when needed (so session will be started when needed). 
