### PR TITLE
Support for the channelUrl parameter of FB.init().

### DIFF
--- a/Controller/FacebookController.php
+++ b/Controller/FacebookController.php
@@ -1,0 +1,44 @@
+<?php
+namespace FOS\FacebookBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\HttpFoundation\Response;
+
+class FacebookController extends ContainerAware
+{       
+    /**
+     * public function channelAction()
+     * 
+     * This function mimics the channel.html file suggested by facebook.
+     * 
+     * References : 
+     * https://developers.facebook.com/docs/reference/javascript/
+     * 
+     * @version         1.0
+     * 
+     * @author          Antoine Durieux
+     * 
+     * @return          Response
+     */
+    public function channelAction()
+    {
+        // Retrieve parameters from the container.
+        $culture = $this->container->getParameter('fos_facebook.culture');
+        $cacheExpire = $this->container->getParameter('fos_facebook.channel.expire');
+
+        // Compute expiration date.
+        $date = new \DateTime();
+        $date->modify('+'.$cacheExpire.' seconds');
+
+        // Generate new response, and set parameters recommended by Facebook.
+        $response = new Response();
+        $response->headers->set("Pragma", "public");
+        $response->setMaxAge($cacheExpire);
+        $response->setExpires($date);
+        $response->setContent('<script src="//connect.facebook.net/'.$culture.'/all.js"></script>');
+
+        return $response;
+    }
+    
+}
+

--- a/Controller/FacebookController.php
+++ b/Controller/FacebookController.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of the FOSFacebookBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FOS\FacebookBundle\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerAware;
@@ -41,4 +51,3 @@ class FacebookController extends ContainerAware
     }
     
 }
-

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,6 +53,14 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('twig')->defaultValue('FOS\FacebookBundle\Twig\Extension\FacebookExtension')->end()
                     ->end()
                 ->end()
+                ->arrayNode('channel')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('use')->defaultValue(true)->end()
+                        ->scalarNode('url')->defaultValue('/channel.html')->end()
+                        ->scalarNode('expire')->defaultValue(60*60*24*365)->end()
+                    ->end()
+                ->end()
                 ->arrayNode('permissions')->prototype('scalar')->end()
             ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -56,8 +56,6 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('channel')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('use')->defaultValue(true)->end()
-                        ->scalarNode('url')->defaultValue('/channel.html')->end()
                         ->scalarNode('expire')->defaultValue(60*60*24*365)->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/FOSFacebookExtension.php
+++ b/DependencyInjection/FOSFacebookExtension.php
@@ -44,7 +44,6 @@ class FOSFacebookExtension extends Extension
             $container->setParameter('fos_facebook.'.$attribute, $config[$attribute]);
         }
         
-        $container->setParameter('fos_facebook.channel.url', $config['channel']['url']);
         $container->setParameter('fos_facebook.channel.expire', $config['channel']['expire']);
     }
 

--- a/DependencyInjection/FOSFacebookExtension.php
+++ b/DependencyInjection/FOSFacebookExtension.php
@@ -43,6 +43,9 @@ class FOSFacebookExtension extends Extension
         foreach (array('file', 'app_id', 'secret', 'cookie', 'domain', 'logging', 'culture', 'permissions') as $attribute) {
             $container->setParameter('fos_facebook.'.$attribute, $config[$attribute]);
         }
+        
+        $container->setParameter('fos_facebook.channel.url', $config['channel']['url']);
+        $container->setParameter('fos_facebook.channel.expire', $config['channel']['expire']);
     }
 
     /**

--- a/Resources/config/facebook.xml
+++ b/Resources/config/facebook.xml
@@ -24,7 +24,6 @@
             <argument>%fos_facebook.logging%</argument>
             <argument>%fos_facebook.culture%</argument>
             <argument>%fos_facebook.permissions%</argument>
-            <argument>%fos_facebook.channel.url%</argument>
             <tag name="templating.helper" alias="facebook" />
         </service>
 

--- a/Resources/config/facebook.xml
+++ b/Resources/config/facebook.xml
@@ -20,9 +20,11 @@
         <service id="fos_facebook.helper" class="%fos_facebook.helper.class%">
             <argument type="service" id="templating" />
             <argument type="service" id="fos_facebook.api" />
+            <argument type="service" id="router" />
             <argument>%fos_facebook.logging%</argument>
             <argument>%fos_facebook.culture%</argument>
             <argument>%fos_facebook.permissions%</argument>
+            <argument>%fos_facebook.channel.url%</argument>
             <tag name="templating.helper" alias="facebook" />
         </service>
 

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_facebook_channel" pattern="/channel.html">
+        <default key="_controller">FOSFacebookBundle:Facebook:channel</default>
+        <requirement key="_method">GET</requirement>
+    </route>
+
+</routes>

--- a/Resources/config/schema/facebook-1.0.xsd
+++ b/Resources/config/schema/facebook-1.0.xsd
@@ -18,12 +18,18 @@
         <xsd:attribute name="logging" type="xsd:boolean" />
         <xsd:attribute name="culture" type="xsd:string" />
         <xsd:attribute name="xfbml" type="xsd:boolean" />
+        <xsd:attribute name="channel" type="channel" />
         <xsd:attribute name="permissions" type="permissions" />
     </xsd:complexType>
-
+    
     <xsd:complexType name="permissions">
         <xsd:sequence>
             <xsd:element name="permission" type="xsd:string" />
         </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="channel">
+        <xsd:attribute name="url" type="xsd:string" />
+        <xsd:attribute name="expire" type="xsd:integer" />
     </xsd:complexType>
 </xsd:schema>

--- a/Resources/config/schema/facebook-1.0.xsd
+++ b/Resources/config/schema/facebook-1.0.xsd
@@ -21,7 +21,7 @@
         <xsd:attribute name="channel" type="channel" />
         <xsd:attribute name="permissions" type="permissions" />
     </xsd:complexType>
-    
+
     <xsd:complexType name="permissions">
         <xsd:sequence>
             <xsd:element name="permission" type="xsd:string" />

--- a/Resources/config/schema/facebook-1.0.xsd
+++ b/Resources/config/schema/facebook-1.0.xsd
@@ -29,7 +29,6 @@
     </xsd:complexType>
 
     <xsd:complexType name="channel">
-        <xsd:attribute name="url" type="xsd:string" />
         <xsd:attribute name="expire" type="xsd:integer" />
     </xsd:complexType>
 </xsd:schema>

--- a/Resources/views/initialize.html.php
+++ b/Resources/views/initialize.html.php
@@ -12,6 +12,7 @@ window.fbAsyncInit = function() {
     'status' =>  $status,
     'oauth'   => $oauth,
     'cookie'  => $cookie,
+    'channelUrl' => $channelUrl,
     'logging' => $logging)) ?>);
 <?php if (!empty($async)) { ?>
     <?php echo $fbAsyncInit ?>

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -7,7 +7,7 @@
 {% if async %}
 window.fbAsyncInit = function() {
 {% endif %}
-  FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging, 'channelUrl':channelUrl}|json_encode}});
+  FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging, 'channelUrl':channelUrl}|json_encode }});
 {% if async %}
   {{ fbAsyncInit }}
 };

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -7,7 +7,7 @@
 {% if async %}
 window.fbAsyncInit = function() {
 {% endif %}
-  FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging }|json_encode }});
+  FB.init({{ {'appId':appId, 'xfbml':xfbml, 'oauth':oauth, 'status':status, 'cookie':cookie, 'logging':logging, 'channelUrl':channelUrl}|json_encode}});
 {% if async %}
   {{ fbAsyncInit }}
 };

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -12,26 +12,26 @@
 namespace FOS\FacebookBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Templating\EngineInterface;
 
 class FacebookHelper extends Helper
 {
     protected $templating;
     protected $logging;
-    protected $routing;
+    protected $urlGenerator;
     protected $culture;
     protected $scope;
     protected $facebook;
 
-    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, RouterInterface $routing = null, $logging = true, $culture = 'en_US', array $scope = array())
+    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, UrlGeneratorInterface $urlGenerator, $logging = true, $culture = 'en_US', array $scope = array())
     {
-        $this->templating  = $templating;
-        $this->logging     = $logging;
-        $this->routing     = $routing;
-        $this->culture     = $culture;
-        $this->scope       = $scope;
-        $this->facebook    = $facebook;
+        $this->templating   = $templating;
+        $this->logging      = $logging;
+        $this->urlGenerator = $urlGenerator;
+        $this->culture      = $culture;
+        $this->scope        = $scope;
+        $this->facebook     = $facebook;
     }
 
     /**
@@ -66,7 +66,7 @@ class FacebookHelper extends Helper
             'status'      => false,
             'cookie'      => true,
             'logging'     => $this->logging,
-            'channelUrl'  => $this->routing->generate('fos_facebook_channel',array(),true),
+            'channelUrl'  => $this->urlGenerator->generate('fos_facebook_channel', array(), true),
             'culture'     => $this->culture,
         ));
     }

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -12,23 +12,28 @@
 namespace FOS\FacebookBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
+use Symfony\Component\Routing\Router;
 use Symfony\Component\Templating\EngineInterface;
 
 class FacebookHelper extends Helper
 {
     protected $templating;
     protected $logging;
+    protected $routing;
     protected $culture;
     protected $scope;
     protected $facebook;
+    protected $channelUrl;
 
-    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, $logging = true, $culture = 'en_US', array $scope = array())
+    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, Router $routing = null,$logging = true, $culture = 'en_US', array $scope = array(),$channelUrl = '/channel.html')
     {
         $this->templating  = $templating;
         $this->logging     = $logging;
+        $this->routing     = $routing;
         $this->culture     = $culture;
         $this->scope       = $scope;
         $this->facebook    = $facebook;
+        $this->channelUrl  = $channelUrl;
     }
 
     /**
@@ -63,6 +68,7 @@ class FacebookHelper extends Helper
             'status'      => false,
             'cookie'      => true,
             'logging'     => $this->logging,
+            'channelUrl'  => $this->routing->getContext()->getHost().$this->channelUrl,
             'culture'     => $this->culture,
         ));
     }

--- a/Templating/Helper/FacebookHelper.php
+++ b/Templating/Helper/FacebookHelper.php
@@ -12,7 +12,7 @@
 namespace FOS\FacebookBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 
 class FacebookHelper extends Helper
@@ -23,9 +23,8 @@ class FacebookHelper extends Helper
     protected $culture;
     protected $scope;
     protected $facebook;
-    protected $channelUrl;
 
-    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, Router $routing = null,$logging = true, $culture = 'en_US', array $scope = array(),$channelUrl = '/channel.html')
+    public function __construct(EngineInterface $templating, \BaseFacebook $facebook, RouterInterface $routing = null, $logging = true, $culture = 'en_US', array $scope = array())
     {
         $this->templating  = $templating;
         $this->logging     = $logging;
@@ -33,7 +32,6 @@ class FacebookHelper extends Helper
         $this->culture     = $culture;
         $this->scope       = $scope;
         $this->facebook    = $facebook;
-        $this->channelUrl  = $channelUrl;
     }
 
     /**
@@ -68,7 +66,7 @@ class FacebookHelper extends Helper
             'status'      => false,
             'cookie'      => true,
             'logging'     => $this->logging,
-            'channelUrl'  => $this->routing->getContext()->getHost().$this->channelUrl,
+            'channelUrl'  => $this->routing->generate('fos_facebook_channel',array(),true),
             'culture'     => $this->culture,
         ));
     }

--- a/Tests/DependencyInjection/FOSFacebookExtensionTest.php
+++ b/Tests/DependencyInjection/FOSFacebookExtensionTest.php
@@ -62,7 +62,7 @@ class FOSFacebookExtensionTest extends \PHPUnit_Framework_TestCase
             array('domain' => 'foo'),
             array('logging' => 'foo'),
             array('culture' => 'foo'),
-            array('channel' => array('url'=>'foo','expire'=>100)),
+            array('channel' => array('expire' => 100)),
             array('permissions' => array('email')),
         );
         $extension->load($configs, $container);
@@ -89,7 +89,7 @@ class FOSFacebookExtensionTest extends \PHPUnit_Framework_TestCase
             array('domain' => 'foo'),
             array('logging' => 'foo'),
             array('culture' => 'foo'),
-            array('channel' => array('url'=>'foo','expire'=>100)),
+            array('channel' => array('expire' => 100)),
             array('permissions' => array('email')),
             array('alias' => 'facebook_alias')
         );

--- a/Tests/DependencyInjection/FOSFacebookExtensionTest.php
+++ b/Tests/DependencyInjection/FOSFacebookExtensionTest.php
@@ -62,6 +62,7 @@ class FOSFacebookExtensionTest extends \PHPUnit_Framework_TestCase
             array('domain' => 'foo'),
             array('logging' => 'foo'),
             array('culture' => 'foo'),
+            array('channel' => array('url'=>'foo','expire'=>100)),
             array('permissions' => array('email')),
         );
         $extension->load($configs, $container);
@@ -88,6 +89,7 @@ class FOSFacebookExtensionTest extends \PHPUnit_Framework_TestCase
             array('domain' => 'foo'),
             array('logging' => 'foo'),
             array('culture' => 'foo'),
+            array('channel' => array('url'=>'foo','expire'=>100)),
             array('permissions' => array('email')),
             array('alias' => 'facebook_alias')
         );

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -42,14 +42,14 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $routing = $this->getMockBuilder('Symfony\Component\Routing\Router')
+        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
             ->disableOriginalConstructor()
             ->getMock();
         $routing
             ->expects($this->once())
             ->method('generate')
             ->will($this->returnValue('/channel.html'));
-        
+
         $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
         $facebookMock->expects($this->once())
             ->method('getAppId')
@@ -78,12 +78,16 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
                 'scope'          => '1,2,3',
             ))
             ->will($this->returnValue($expected));
-        
+
+        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
         $facebookMock->expects($this->any())
             ->method('getAppId');
 
-        $helper = new FacebookHelper($templating, $facebookMock, null, true, 'en_US', array(1,2,3) );
+        $helper = new FacebookHelper($templating, $facebookMock, $routing, true, 'en_US', array(1,2,3) );
         $this->assertSame($expected, $helper->loginButton(array('label' => 'testLabel')));
     }
 }

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -42,21 +42,13 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $context = $this->getMockBuilder('Symfony\Component\Routing\RequestContext')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $context
-            ->expects($this->once())
-            ->method('getHost')
-            ->will($this->returnValue(''));
-
         $routing = $this->getMockBuilder('Symfony\Component\Routing\Router')
             ->disableOriginalConstructor()
             ->getMock();
         $routing
             ->expects($this->once())
-            ->method('getContext')
-            ->will($this->returnValue($context));
+            ->method('generate')
+            ->will($this->returnValue('/channel.html'));
         
         $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
         $facebookMock->expects($this->once())

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -79,7 +79,7 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
+        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -37,16 +37,33 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
                 'logging' => true,
                 'oauth' => true,
                 'status'  => false,
+                'channelUrl' => '/channel.html',
                 'xfbml'   => false,
             ))
             ->will($this->returnValue($expected));
 
+        $context = $this->getMockBuilder('Symfony\Component\Routing\RequestContext')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context
+            ->expects($this->once())
+            ->method('getHost')
+            ->will($this->returnValue(''));
+
+        $routing = $this->getMockBuilder('Symfony\Component\Routing\Router')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $routing
+            ->expects($this->once())
+            ->method('getContext')
+            ->will($this->returnValue($context));
+        
         $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
         $facebookMock->expects($this->once())
             ->method('getAppId')
             ->will($this->returnValue('123'));
 
-        $helper = new FacebookHelper($templating, $facebookMock);
+        $helper = new FacebookHelper($templating, $facebookMock, $routing);
         $this->assertSame($expected, $helper->initialize(array('cookie' => false)));
     }
 
@@ -69,12 +86,12 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
                 'scope'          => '1,2,3',
             ))
             ->will($this->returnValue($expected));
-
+        
         $facebookMock = $this->getMock('\BaseFacebook', array('getAppId'));
         $facebookMock->expects($this->any())
             ->method('getAppId');
 
-        $helper = new FacebookHelper($templating, $facebookMock, true, 'en_US', array(1,2,3) );
+        $helper = new FacebookHelper($templating, $facebookMock, null, true, 'en_US', array(1,2,3) );
         $this->assertSame($expected, $helper->loginButton(array('label' => 'testLabel')));
     }
 }

--- a/Tests/Templating/Helper/FacebookHelperTest.php
+++ b/Tests/Templating/Helper/FacebookHelperTest.php
@@ -42,7 +42,7 @@ class FacebookHelperTest extends \PHPUnit_Framework_TestCase
             ))
             ->will($this->returnValue($expected));
 
-        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
+        $routing = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')
             ->disableOriginalConstructor()
             ->getMock();
         $routing


### PR DESCRIPTION
**Description :** 

The Facebook developer's website highly recommends to create a channel.html file in order to address some Cross-Domain issues.

**Todo:**
- `Resources/config/routing.xml` : The route pattern should follow the `fos_facebook.channel.url` parameter of the `config/facebook.xml` file.
- `Resources/views/initialize.html.twig` l.10 : there might be a bug here : do we have to escape the URL ?
- `Templating/Helper/FacebookHelper.php` l.71 : not quite sure that this is the right place to do that...
- Code review welcome for these points...

**Bug fix:** no
**Feature addition:** yes
**Backwards compatibility break:** no
**Bundle tests pass:** yes 
**Fixes the following tickets:** #113
**References the following tickets:** -
**External references :** https://developers.facebook.com/docs/reference/javascript/
