### PR TITLE
Fix for session instance error.

### DIFF
--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -21,7 +21,7 @@ class FacebookSessionPersistence extends \BaseFacebook
     * @param array $config the application configuration.
     * @see BaseFacebook::__construct in facebook.php
     */
-    public function __construct($config, Session $session, $prefix = self::PREFIX)
+    public function __construct($config, Session\Session $session, $prefix = self::PREFIX)
     {
         $this->session = $session;
         $this->prefix  = $prefix;

--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -2,7 +2,7 @@
 
 namespace FOS\FacebookBundle\Facebook;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * Implements Symfony2 session persistence for Facebook.
@@ -21,7 +21,7 @@ class FacebookSessionPersistence extends \BaseFacebook
     * @param array $config the application configuration.
     * @see BaseFacebook::__construct in facebook.php
     */
-    public function __construct($config, Session\Session $session, $prefix = self::PREFIX)
+    public function __construct($config, Session $session, $prefix = self::PREFIX)
     {
         $this->session = $session;
         $this->prefix  = $prefix;


### PR DESCRIPTION
The error received:

Catchable Fatal Error: Argument 2 passed to FOS\FacebookBundle\Facebook\FacebookSessionPersistence::__construct() must be an instance of Symfony\Component\HttpFoundation\Session, instance of Symfony\Component\HttpFoundation\Session\Session given, called in /var/www/RealUP/app/cache/dev/appDevDebugProjectContainer.php on line 914 and defined in /var/www/RealUP/vendor/bundles/FOS/FacebookBundle/Facebook/FacebookSessionPersistence.php line 24 
