### PR TITLE
Changing URL for Facebook SDK to the new location

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
                 "name": "facebook/php-sdk",
                 "version": "3.1.1",
                 "source": {
-                    "url": "git://github.com/facebook/php-sdk.git",
+                    "url": "git://github.com/facebook/facebook-php-sdk.git",
                     "type": "git",
                     "reference": "origin/master"
                 }


### PR DESCRIPTION
From the [old Facebook SDK Github page](https://github.com/facebook/php-sdk):

> Please update anything you have pointing at this repostory to this location before April 1, 2012.
