### PR TITLE
Add provider key to authentication provider

### DIFF
--- a/DependencyInjection/Security/Factory/FacebookFactory.php
+++ b/DependencyInjection/Security/Factory/FacebookFactory.php
@@ -43,22 +43,22 @@ class FacebookFactory extends AbstractFactory
 
     protected function createAuthProvider(ContainerBuilder $container, $id, $config, $userProviderId)
     {
+        $authProviderId = 'fos_facebook.auth.'.$id;
+
+        $definition = $container
+            ->setDefinition($authProviderId, new DefinitionDecorator('fos_facebook.auth'))
+            ->replaceArgument(0, $id);
+
         // with user provider
         if (isset($config['provider'])) {
-            $authProviderId = 'fos_facebook.auth.'.$id;
-
-            $container
-                ->setDefinition($authProviderId, new DefinitionDecorator('fos_facebook.auth'))
+            $definition
                 ->addArgument(new Reference($userProviderId))
                 ->addArgument(new Reference('security.user_checker'))
                 ->addArgument($config['create_user_if_not_exists'])
             ;
-
-            return $authProviderId;
         }
 
-        // without user provider
-        return 'fos_facebook.auth';
+        return $authProviderId;
     }
 
     protected function createEntryPoint($container, $id, $config, $defaultEntryPointId)

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -6,9 +6,10 @@
 
     <services>
         <service id="fos_facebook.auth" class="FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider" public="false">
+            <argument /> <!-- Provider-shared Key -->
             <argument type="service" id="fos_facebook.api" />
         </service>
-        
+
         <service id="fos_facebook.logout_handler" class="FOS\FacebookBundle\Security\Logout\FacebookHandler" public="false">
             <argument type="service" id="fos_facebook.api" />
         </service>

--- a/Security/Authentication/Token/FacebookUserToken.php
+++ b/Security/Authentication/Token/FacebookUserToken.php
@@ -15,7 +15,9 @@ use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 
 class FacebookUserToken extends AbstractToken
 {
-    public function __construct($uid = '', array $roles = array())
+    private $providerKey;
+
+    public function __construct($providerKey, $uid = '', array $roles = array())
     {
         parent::__construct($roles);
 
@@ -24,10 +26,17 @@ class FacebookUserToken extends AbstractToken
         if (!empty($uid)) {
             $this->setAuthenticated(true);
         }
+
+        $this->providerKey = $providerKey;
     }
 
     public function getCredentials()
     {
         return '';
+    }
+
+    public function getProviderKey()
+    {
+        return $this->providerKey;
     }
 }

--- a/Security/Authentication/Token/FacebookUserToken.php
+++ b/Security/Authentication/Token/FacebookUserToken.php
@@ -39,4 +39,15 @@ class FacebookUserToken extends AbstractToken
     {
         return $this->providerKey;
     }
+
+    public function serialize()
+    {
+        return serialize(array($this->providerKey, parent::serialize()));
+    }
+
+    public function unserialize($str)
+    {
+        list($this->providerKey, $parentStr) = unserialize($str);
+        parent::unserialize($parentStr);
+    }
 }

--- a/Security/Firewall/FacebookListener.php
+++ b/Security/Firewall/FacebookListener.php
@@ -22,6 +22,6 @@ class FacebookListener extends AbstractAuthenticationListener
 {
     protected function attemptAuthentication(Request $request)
     {
-        return $this->authenticationManager->authenticate(new FacebookUserToken());
+        return $this->authenticationManager->authenticate(new FacebookUserToken($this->providerKey));
     }
 }

--- a/Tests/DependencyInjection/Security/Factory/FacebookFactoryTest.php
+++ b/Tests/DependencyInjection/Security/Factory/FacebookFactoryTest.php
@@ -47,10 +47,22 @@ class FacebookFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers FOS\FacebookBundle\DependencyInjection\Security\Factory\FacebookFactory::createAuthProvider
      */
-    public function testThatDoNotCreateUserAuthProviderWhenNotDefinedInConfig()
+    public function testThatCreateUserAuthProviderEvenWhenNotDefinedInConfig()
     {
         $idsArray = $this->facebookFactoryCreate(array('remember_me' => false));
-        $this->assertEquals('fos_facebook.auth', $idsArray[0]);
+        $this->assertEquals('fos_facebook.auth.l3l0', $idsArray[0]);
+    }
+
+    /**
+     * @covers FOS\FacebookBundle\DependencyInjection\Security\Factory\FacebookFactory::createAuthProvider
+     */
+    public function testThatCreateDifferentUserAuthProviderForDifferentFirewalls()
+    {
+        $idsArray = $this->facebookFactoryCreate(array('remember_me' => false));
+        $this->assertEquals('fos_facebook.auth.l3l0', $idsArray[0]);
+
+        $idsArray = $this->facebookFactoryCreate(array('remember_me' => false), 'main');
+        $this->assertEquals('fos_facebook.auth.main', $idsArray[0]);
     }
 
     /**
@@ -75,7 +87,7 @@ class FacebookFactoryTest extends \PHPUnit_Framework_TestCase
      * @param array $config
      * @return array
      */
-    private function facebookFactoryCreate($config = array())
+    private function facebookFactoryCreate($config = array(), $id = 'l3l0')
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('addArgument', 'replaceArgument'));
         $definition->expects($this->any())
@@ -89,6 +101,6 @@ class FacebookFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('setDefinition')
             ->will($this->returnValue($definition));
 
-        return $this->factory->create($container, 'l3l0', $config, 'l3l0.user.provider', null);
+        return $this->factory->create($container, $id, $config, 'l3l0.user.provider', null);
     }
 }

--- a/Tests/Security/Authentication/Provider/FacebookProviderTest.php
+++ b/Tests/Security/Authentication/Provider/FacebookProviderTest.php
@@ -35,6 +35,27 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider::authenticate
+     * @covers FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider::supports
+     */
+    public function testThatCannotAuthenticateWhenTokenFromOtherFirewall()
+    {
+        $providerKeyForProvider = 'main';
+        $providerKeyForToken    = 'connect';
+
+        $facebookProvider = new FacebookProvider($providerKeyForProvider, $this->getMock('\BaseFacebook'));
+
+        $tokenMock = $this->getMock('FOS\FacebookBundle\Security\Authentication\Token\FacebookUserToken', array('getProviderKey'), array($providerKeyForToken));
+        $tokenMock->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue($providerKeyForToken));
+
+        $this->assertFalse($facebookProvider->supports($tokenMock));
+        $this->assertNull($facebookProvider->authenticate($tokenMock));
+    }
+
+    /**
+     * @covers FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider::authenticate
+     * @covers FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider::supports
      * @covers FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider::createAuthenticatedToken
      */
     public function testThatCanAuthenticateUserWithoutUserProvider()
@@ -56,6 +77,7 @@ class FacebookProviderTest extends \PHPUnit_Framework_TestCase
             ->method('getProviderKey')
             ->will($this->returnValue($providerKey));
 
+        $this->assertTrue($facebookProvider->supports($tokenMock));
         $this->assertEquals('123', $facebookProvider->authenticate($tokenMock)->getUser());
     }
 

--- a/Tests/Security/Authentication/Token/FacebookUserTokenTest.php
+++ b/Tests/Security/Authentication/Token/FacebookUserTokenTest.php
@@ -20,7 +20,7 @@ class FacebookUserTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatAlwaysReturnEmptyCredentials($uid, $roles)
     {
-        $token = new FacebookUserToken($uid, $roles);
+        $token = new FacebookUserToken('main', $uid, $roles);
 
         $this->assertEquals('', $token->getCredentials());
     }

--- a/Tests/Security/Authentication/Token/FacebookUserTokenTest.php
+++ b/Tests/Security/Authentication/Token/FacebookUserTokenTest.php
@@ -37,4 +37,12 @@ class FacebookUserTokenTest extends \PHPUnit_Framework_TestCase
             array('l3l0', array('role1', 'role2'))
         );
     }
+
+    public function testThatProviderKeyIsNotEmptyAfterDeserialization()
+    {
+        $providerKey = 'main';
+        $token = unserialize(serialize(new FacebookUserToken($providerKey)));
+
+        $this->assertEquals($providerKey, $token->getProviderKey());
+    }
 }


### PR DESCRIPTION
Sometimes we need use fos-facebook more than once (in different firewalls). This PR fixes situation when token from firewall B tryed to be authenticated by firewall A.
