### PR TITLE
[Config] Set the file parameter optional

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('app_id')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('secret')->isRequired()->cannotBeEmpty()->end()
-                ->scalarNode('file')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('file')->defaultNull()->end()
                 ->scalarNode('cookie')->defaultFalse()->end()
                 ->scalarNode('domain')->defaultNull()->end()
                 ->scalarNode('alias')->defaultNull()->end()

--- a/DependencyInjection/FOSFacebookExtension.php
+++ b/DependencyInjection/FOSFacebookExtension.php
@@ -40,8 +40,13 @@ class FOSFacebookExtension extends Extension
             $container->setParameter('fos_facebook.'.$attribute.'.class', $config['class'][$attribute]);
         }
 
-        foreach (array('file', 'app_id', 'secret', 'cookie', 'domain', 'logging', 'culture', 'permissions') as $attribute) {
+        foreach (array('app_id', 'secret', 'cookie', 'domain', 'logging', 'culture', 'permissions') as $attribute) {
             $container->setParameter('fos_facebook.'.$attribute, $config[$attribute]);
+        }
+
+        if (isset($config['file']) && $container->hasDefinition('fos_facebook.api')) {
+            $facebookApi = $container->getDefinition('fos_facebook.api');
+            $facebookApi->setFile($config['file']);
         }
     }
 

--- a/Resources/config/facebook.xml
+++ b/Resources/config/facebook.xml
@@ -7,7 +7,6 @@
     <services>
 
         <service id="fos_facebook.api" class="%fos_facebook.api.class%">
-            <file>%fos_facebook.file%</file>
             <argument type="collection">
                 <argument key="appId">%fos_facebook.app_id%</argument>
                 <argument key="secret">%fos_facebook.secret%</argument>


### PR DESCRIPTION
According to the `README`, the `fos_facebook.file` parameter should be optional.

This PR resolves #140
