### PR TITLE
Return javascript always to not cause X-Frame-Options restrictions

### DIFF
--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -14,7 +14,6 @@ namespace FOS\FacebookBundle\Security\EntryPoint;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -51,18 +50,14 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
         if ($this->options->get('server_url') && $this->options->get('app_url')) {
             $redirect_uri = str_replace($this->options->get('server_url'), $this->options->get('app_url'), $redirect_uri);
         }
-        
+
         $loginUrl = $this->facebook->getLoginUrl(
            array(
                 'display' => $this->options->get('display', 'page'),
                 'scope' => implode(',', $this->permissions),
                 'redirect_uri' => $redirect_uri,
         ));
-        
-        if ($this->options->get('server_url') && $this->options->get('app_url')){
-            return new Response('<html><head></head><body><script>top.location.href="'.$loginUrl.'";</script></body></html>');
-        }
-        
-        return new RedirectResponse($loginUrl);
+
+        return new Response('<html><head></head><body><script>top.location.href="'.$loginUrl.'";</script></body></html>');
     }
 }


### PR DESCRIPTION
Returning a `RedirectResponse` will cause Chrome to refuse the redirect with "Refused to display document because display forbidden by X-Frame-Options."
Other browsers might output an error page saying "content can not be loaded in a frame".
