### PR TITLE
Fix redirect url replacing.

### DIFF
--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -49,7 +49,11 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
     {
         $redirect_uri = $request->getUriForPath($this->options->get('check_path', ''));
         if ($this->options->get('server_url') && $this->options->get('app_url')) {
-            $redirect_uri = str_replace($this->options->get('server_url'), $this->options->get('app_url'), $redirect_uri);
+            $redirect_uri = str_replace(
+                preg_replace("/(http:\/\/)/i", "", $this->options->get('server_url')),
+                preg_replace("/(http:\/\/)/i", "", $this->options->get('app_url')),
+                $redirect_uri
+            );
         }
         
         $loginUrl = $this->facebook->getLoginUrl(


### PR DESCRIPTION
If we have in server_url addres with "http" and user browse page with https when $redirect_uri will be broken and user will land on server page - not app. preg_replace removes http:// or https:// from urls and redirects user properly.
