### PR TITLE
Switch variables from private to protected

### DIFF
--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -13,8 +13,8 @@ class FacebookSessionPersistence extends \BaseFacebook
 {
     const PREFIX = '_fos_facebook_';
 
-    private $session;
-    private $prefix;
+    protected $session;
+    protected $prefix;
     protected static $kSupportedKeys = array('state', 'code', 'access_token', 'user_id');
 
    /**


### PR DESCRIPTION
We can't extend this class because of those 2 private variables, it causes problem when calling properties on $session from the getPersistentData method.

It fails on this line because $session is not accessible.

``` php
if ($this->session->has($sessionVariableName)) {
```
