### PR TITLE
change FacebookSession class variable visibility to protected

### DIFF
--- a/Facebook/FacebookSessionPersistence.php
+++ b/Facebook/FacebookSessionPersistence.php
@@ -13,8 +13,8 @@ class FacebookSessionPersistence extends \BaseFacebook
 {
     const PREFIX = '_fos_facebook_';
 
-    private $session;
-    private $prefix;
+    protected $session;
+    protected $prefix;
     protected static $kSupportedKeys = array('state', 'code', 'access_token', 'user_id');
 
    /**


### PR DESCRIPTION
Simple change to allow extension of this class.

Specifically, trying to override constructor method is impossible because of private visibility.
