### PR TITLE
Incorrect facebook SDK path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ php composer.phar update friendsofsymfony/facebook-bundle
 
           # application/config/config.yml
           fos_facebook:
-              file:   %kernel.root_dir%/../vendor/facebook/src/base_facebook.php
+              file:   %kernel.root_dir%/../vendor/facebook/php-sdk/src/base_facebook.php
               alias:  facebook
               app_id: 123456879
               secret: s3cr3t
@@ -95,7 +95,7 @@ $ php composer.phar update friendsofsymfony/facebook-bundle
 
           # application/config/config.xml
           <fos_facebook:api
-              file="%kernel.root_dir%/../vendor/facebook/src/base_facebook.php"
+              file="%kernel.root_dir%/../vendor/facebook/php-sdk/src/base_facebook.php"
               alias="facebook"
               app_id="123456879"
               secret="s3cr3t"


### PR DESCRIPTION
They changed the repository some time ago, this part of the README wasn't updated.
