### PR TITLE
fixed AuthenticationException throwing to match the changed signature

### DIFF
--- a/Security/Authentication/Provider/FacebookProvider.php
+++ b/Security/Authentication/Provider/FacebookProvider.php
@@ -78,7 +78,7 @@ class FacebookProvider implements AuthenticationProviderInterface
         } catch (AuthenticationException $failed) {
             throw $failed;
         } catch (\Exception $failed) {
-            throw new AuthenticationException($failed->getMessage(), null, (int)$failed->getCode(), $failed);
+            throw new AuthenticationException($failed->getMessage(), (int)$failed->getCode(), $failed);
         }
 
         throw new AuthenticationException('The Facebook user could not be retrieved from the session.');


### PR DESCRIPTION
AuthenticationException siganture has changed in https://github.com/symfony/symfony/commit/694c47ce9626568efee496accf6ff5a564cbc83e to match \Exception signature. My pull request fixes the FacebookProvider when throwing such an exception.
