### PR TITLE
Remove bundle dependencies to use with Silex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,14 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1,<2.3",
-        "symfony/security-bundle": ">=2.1,<2.3",
-        "symfony/twig-bundle": ">=2.1,<2.3",
+        "symfony/http-foundation": ">=2.1,<2.3",
+        "symfony/security": ">=2.1,<2.3",
         "facebook/php-sdk": "3.2.*"
     },
     "require-dev": {
+        "symfony/framework-bundle": ">=2.1,<2.3",
+        "symfony/security-bundle": ">=2.1,<2.3",
+        "symfony/twig-bundle": ">=2.1,<2.3",
         "phpunit/phpunit": "3.7.*"
     },
     "config": {


### PR DESCRIPTION
The Security and SessionPersistance classes can be used outside of the fullstack framework.

Example: https://github.com/GromNaN/FacebookServiceProvider
