### PR TITLE
Remove bundle dependencies to use with Silex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ php:
   - 5.4
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php --
-  - php composer.phar install
+  - composer install --dev --prefer-dist
 
 script: phpunit --coverage-text
 

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,14 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1,<2.3",
-        "symfony/security-bundle": ">=2.1,<2.3",
-        "symfony/twig-bundle": ">=2.1,<2.3",
+        "symfony/http-foundation": ">=2.1,<2.3",
+        "symfony/security": ">=2.1,<2.3",
         "facebook/php-sdk": "3.2.*"
     },
     "require-dev": {
+        "symfony/framework-bundle": ">=2.1,<2.3",
+        "symfony/security-bundle": ">=2.1,<2.3",
+        "symfony/twig-bundle": ">=2.1,<2.3",
         "phpunit/phpunit": "3.7.*"
     },
     "config": {


### PR DESCRIPTION
I resubmit PR #238 because it was not updated by the new push.

The Security and SessionPersistance classes can be used outside of the fullstack framework.

Example: https://github.com/GromNaN/FacebookServiceProvider
