### PR TITLE
Replaced PHP code with twig variable

### DIFF
--- a/Resources/views/loginButton.html.twig
+++ b/Resources/views/loginButton.html.twig
@@ -1,3 +1,3 @@
-<div class="fb-login-button" data-show-faces="{{ showfaces }}" data-size="{{ size }}" data-scope="{{ scope }}" data-autologoutlink="{{ autologoutlink }}" data-width="{{ width }}" data-max-rows="{{ maxRows }}"  data-onlogin="<?php echo $onlogin; ?>">
+<div class="fb-login-button" data-show-faces="{{ showfaces }}" data-size="{{ size }}" data-scope="{{ scope }}" data-autologoutlink="{{ autologoutlink }}" data-width="{{ width }}" data-max-rows="{{ maxRows }}"  data-onlogin="{{ onlogin }}">
   {{ label }}
 </div>


### PR DESCRIPTION
The twig template for the facebook login button contains a PHP echo statement rather than a twig variable. This fix replaces it with a twig variable of the same name.
