### PR TITLE
Define create_user_if_not_exists option as true by default

### DIFF
--- a/DependencyInjection/Security/Factory/FacebookFactory.php
+++ b/DependencyInjection/Security/Factory/FacebookFactory.php
@@ -23,7 +23,7 @@ class FacebookFactory extends AbstractFactory
         $this->addOption('display', 'page');
         $this->addOption('app_url');
         $this->addOption('server_url');
-        $this->addOption('create_user_if_not_exists', false);
+        $this->addOption('create_user_if_not_exists', true);
         $this->addOption('redirect_to_facebook_login', true);
     }
 


### PR DESCRIPTION
FacebookFactory defines create_user_if_not_exists as false and the FacebookProvider implementation in the docs has a **load**UserByUsername which **create** a new user if this does not exists and ignore the create_user_if_not_exists options.

What this PR does:
1. Define create_user_if_not_exists true by default
2. Add to the documentation a FacebookProvider that creates the user only if create_user_if_not_exists is true.

Users can now switch creation of new users by altering the configuration params and the FacebookProvider implementation looks more obvious.

Feedback ?
