### PR TITLE
[doc] Add 'Default' validation group for user validation

### DIFF
--- a/Resources/doc/2-integration-with-fosuserbundle.md
+++ b/Resources/doc/2-integration-with-fosuserbundle.md
@@ -79,7 +79,7 @@ to the provider id in the "provider" section in ```config.yml```:
                 // TODO use http://developers.facebook.com/docs/api/realtime
                 $user->setFBData($fbdata);
 
-                if (count($this->validator->validate($user, 'Facebook'))) {
+                if (count($this->validator->validate($user, ['Default', 'Facebook']))) {
                     // TODO: the user was found obviously, but doesnt match our expectations, do something smart
                     throw new UsernameNotFoundException('The facebook user could not be stored');
                 }


### PR DESCRIPTION
Having just `Facebook` validation group ignores all rules not `Facebook`.

I think the most common use case is when we want:
- all validation rules to apply to Facebook users (validation group `Default`),
- plus some specific (validation group `Facebook`).
