### PR TITLE
expose options to be able to set server_url and app_url based on request

### DIFF
--- a/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
+++ b/Security/EntryPoint/FacebookAuthenticationEntryPoint.php
@@ -58,18 +58,23 @@ class FacebookAuthenticationEntryPoint implements AuthenticationEntryPointInterf
         if ($this->options->get('server_url') && $this->options->get('app_url')) {
             $redirect_uri = str_replace($this->options->get('server_url'), $this->options->get('app_url'), $redirect_uri);
         }
-        
+
         $loginUrl = $this->facebook->getLoginUrl(
            array(
                 'display' => $this->options->get('display', 'page'),
                 'scope' => implode(',', $this->permissions),
                 'redirect_uri' => $redirect_uri,
         ));
-        
+
         if ($this->options->get('server_url') && $this->options->get('app_url')){
             return new Response('<html><head></head><body><script>top.location.href="'.$loginUrl.'";</script></body></html>');
         }
-        
+
         return new RedirectResponse($loginUrl);
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
     }
 }


### PR DESCRIPTION
We are building a multisite facebook app so we need to be able to set the server_url and app_url based on some information stored in the database to generate the proper urls for the facebook login.

Without that change there is no way to set this as the options are only passed once in the constructor and are not accessible after.
