### PR TITLE
Update 2-integration-with-fosuserbundle.md

### DIFF
--- a/Resources/doc/2-integration-with-fosuserbundle.md
+++ b/Resources/doc/2-integration-with-fosuserbundle.md
@@ -35,12 +35,23 @@ to the provider id in the "provider" section in ```config.yml```:
 
     class FacebookProvider implements UserProviderInterface
     {
-        /**
-         * @var \Facebook
-         */
-        protected $facebook;
-        protected $userManager;
-        protected $validator;
+    		/**
+    		 * @var \FOS\FacebookBundle\Facebook\FacebookSessionPersistence
+    		 */
+    		protected $facebook;
+    		/**
+    		 * @var \FOS\UserBundle\Doctrine\UserManager $userManager
+    		 */
+    		protected $userManager;
+    		/**
+    		 * @var \Symfony\Component\Validator\Validator $validator
+    		 */
+    		protected $validator;
+    
+    		/**
+    		 * @var \FOS\UserBundle\Security\UserProvider $userProvider
+    		 */
+    		protected $userProvider;
 
         public function __construct(BaseFacebook $facebook, $userManager, $validator)
         {
@@ -51,7 +62,7 @@ to the provider id in the "provider" section in ```config.yml```:
 
         public function supportsClass($class)
         {
-            return $this->userManager->supportsClass($class);
+			      return $this->userProvider->supportsClass($class);
         }
 
         public function findUserByFbId($fbId)


### PR DESCRIPTION
Annotations so certain IDEs will not complain about unknown methods (PHPStorm for me) and added a $userProvider which is suggested by the UserManager class because userManager->supportsClass() is deprecated on the userManager and suggests to use UserProvider.

I changed the annotation of $facebook based on the argument in config.yml it points to the fos_facebook.api service which is the class I put above.

(I don't know why the indentation is all weird it looked fine in the editor.)
